### PR TITLE
Implemented env from resolution path fetching in client

### DIFF
--- a/packages/client/tests/test_env_with_invoke.rs
+++ b/packages/client/tests/test_env_with_invoke.rs
@@ -4,7 +4,10 @@ use polywrap_client::msgpack::msgpack;
 
 use polywrap_core::client::ClientConfig;
 use polywrap_core::file_reader::SimpleFileReader;
+use polywrap_core::resolvers::recursive_resolver::RecursiveResolver;
 use polywrap_core::resolvers::static_resolver::StaticResolver;
+use polywrap_core::resolvers::uri_resolution_context::UriPackageOrWrapper;
+use polywrap_core::resolvers::uri_resolver_like::UriResolverLike;
 use polywrap_resolvers::base_resolver::BaseResolver;
 use polywrap_resolvers::simple_file_resolver::FilesystemResolver;
 use polywrap_tests_utils::helpers::get_tests_path;
@@ -236,113 +239,113 @@ fn invoke_method_with_optional_env_works_without_env() {
     assert_eq!(result, None);
 }
 
-// TODO: this test requires getEnvFromUriHistory feature to be implemented
-// Issue: https://github.com/polywrap/rust-client/issues/79
-// #[test]
-// fn env_can_be_registered_for_any_uri_in_resolution_path() {
-//     let wrapper_uri = get_env_wrapper_uri();
-//     let redirect_from_uri = Uri::try_from("mock/from").unwrap();
+#[test]
+fn env_can_be_registered_for_any_uri_in_resolution_path() {
+    let wrapper_uri = get_env_wrapper_uri();
+    let redirect_from_uri = Uri::try_from("mock/from").unwrap();
 
-//     let env = Env {
-//         str: "string".to_string(),
-//         optStr: None,
-//         optFilledStr: Some("optional string".to_string()),
-//         number: 10,
-//         optNumber: None,
-//         bool: true,
-//         optBool: None,
-//         en: 0,
-//         optEnum: None,
-//         object: HashMap::from([
-//             ("prop".to_string(), "object string".to_string()),
-//         ]),
-//         optObject: None,
-//         array: vec![32, 23],
-//     };
+    let env = Env {
+        str: "string".to_string(),
+        optStr: None,
+        optFilledStr: Some("optional string".to_string()),
+        number: 10,
+        optNumber: None,
+        bool: true,
+        optBool: None,
+        en: 0,
+        optEnum: None,
+        object: HashMap::from([
+            ("prop".to_string(), "object string".to_string()),
+        ]),
+        optObject: None,
+        array: vec![32, 23],
+    };
 
-//     // Register the env for the redirect_from_uri which will be redirected to the wrapper_uri
-//     {
-//         let client = {
-//             let mut envs: Envs = HashMap::new();
+    // Register the env for the redirect_from_uri which will be redirected to the wrapper_uri
+    {
+        let client = {
+            let mut envs: Envs = HashMap::new();
         
-//             envs.insert(redirect_from_uri.to_string(), json!(env));
+            envs.insert(redirect_from_uri.to_string(), json!(env));
         
-//             let resolvers = HashMap::from([
-//                 (
-//                     redirect_from_uri.to_string(),
-//                     UriPackageOrWrapper::Uri(wrapper_uri.clone())
-//                 ),
-//             ]);
+            let resolvers = HashMap::from([
+                (
+                    redirect_from_uri.to_string(),
+                    UriPackageOrWrapper::Uri(wrapper_uri.clone())
+                ),
+            ]);
         
-//             let file_reader = SimpleFileReader::new();
-//             let fs_resolver = FilesystemResolver::new(Arc::new(file_reader));
+            let file_reader = SimpleFileReader::new();
+            let fs_resolver = FilesystemResolver::new(Arc::new(file_reader));
         
-//             let base_resolver = BaseResolver::new(
-//                 Box::new(fs_resolver),
-//                 Box::new(StaticResolver::new(resolvers)),
-//             );
-//             let config = ClientConfig {
-//                 envs: Some(envs),
-//                 resolver: Arc::new(base_resolver),
-//                 interfaces: None,
-//             };
+            // Use the RecursiveResolver because it tracks resolution path (unlike BaseResolver)
+            let base_resolver = RecursiveResolver::from(vec![
+                UriResolverLike::Resolver(Arc::new(StaticResolver::new(resolvers))),
+                UriResolverLike::Resolver(Arc::new(fs_resolver)),
+            ]);
+            let config = ClientConfig {
+                envs: Some(envs),
+                resolver: Arc::new(base_resolver),
+                interfaces: None,
+            };
             
-//             PolywrapClient::new(config)
-//         };
+            PolywrapClient::new(config)
+        };
 
-//         let result = client
-//             .invoke::<Env>(
-//                 &redirect_from_uri,
-//                 "methodRequireEnv",
-//                 Some(&msgpack!({})),
-//                 None,
-//                 None,
-//             )
-//             .unwrap();
+        let result = client
+            .invoke::<Env>(
+                &redirect_from_uri,
+                "methodRequireEnv",
+                Some(&msgpack!({})),
+                None,
+                None,
+            )
+            .unwrap();
 
-//         assert_eq!(result, env);
-//     }
+        assert_eq!(result, env);
+    }
 
-//     // Register the env for the wrapper_uri which will be redirected to, from the redirect_from_uri
-//     {
-//         let client = {
-//             let mut envs: Envs = HashMap::new();
+    // Register the env for the wrapper_uri which will be redirected to, from the redirect_from_uri
+    {
+        let client = {
+            let mut envs: Envs = HashMap::new();
         
-//             envs.insert(wrapper_uri.to_string(), json!(env));
+            envs.insert(wrapper_uri.to_string(), json!(env));
         
-//             let resolvers = HashMap::from([
-//                 (
-//                     redirect_from_uri.to_string(),
-//                     UriPackageOrWrapper::Uri(wrapper_uri.clone())
-//                 ),
-//             ]);
+            let resolvers = HashMap::from([
+                (
+                    redirect_from_uri.to_string(),
+                    UriPackageOrWrapper::Uri(wrapper_uri.clone())
+                ),
+            ]);
         
-//             let file_reader = SimpleFileReader::new();
-//             let fs_resolver = FilesystemResolver::new(Arc::new(file_reader));
+            let file_reader = SimpleFileReader::new();
+            let fs_resolver = FilesystemResolver::new(Arc::new(file_reader));
         
-//             let base_resolver = BaseResolver::new(
-//                 Box::new(fs_resolver),
-//                 Box::new(StaticResolver::new(resolvers)),
-//             );
-//             let config = ClientConfig {
-//                 envs: Some(envs),
-//                 resolver: Arc::new(base_resolver),
-//                 interfaces: None,
-//             };
+            // Use the RecursiveResolver because it tracks resolution path (unlike BaseResolver)
+            let base_resolver = RecursiveResolver::from(vec![
+                UriResolverLike::Resolver(Arc::new(StaticResolver::new(resolvers))),
+                UriResolverLike::Resolver(Arc::new(fs_resolver)),
+            ]);
+            let config = ClientConfig {
+                envs: Some(envs),
+                resolver: Arc::new(base_resolver),
+                interfaces: None,
+            };
             
-//             PolywrapClient::new(config)
-//         };
+            PolywrapClient::new(config)
+        };
 
-//         let result = client
-//             .invoke::<Env>(
-//                 &redirect_from_uri,
-//                 "methodRequireEnv",
-//                 Some(&msgpack!({})),
-//                 None,
-//                 None,
-//             )
-//             .unwrap();
+        let result = client
+            .invoke::<Env>(
+                &redirect_from_uri,
+                "methodRequireEnv",
+                Some(&msgpack!({})),
+                None,
+                None,
+            )
+            .unwrap();
 
-//         assert_eq!(result, env);
-//     }
-// }
+        assert_eq!(result, env);
+    }
+}

--- a/packages/core/src/resolvers/helpers.rs
+++ b/packages/core/src/resolvers/helpers.rs
@@ -5,7 +5,7 @@ use crate::{
     file_reader::FileReader,
     uri::Uri,
     error::Error,
-    interface_implementation::InterfaceImplementations, client::Client, invoker::Invoker
+    interface_implementation::InterfaceImplementations, client::Client, invoker::Invoker, env::Env
 };
 use polywrap_msgpack::{msgpack};
 
@@ -102,3 +102,19 @@ pub fn get_implementations(
     //     if implementation_uris.contains(x)
     // }
 }
+
+pub fn get_env_from_resolution_path<'a>(
+    resolution_path: &[Uri],
+    client: &'a dyn Client
+) -> Option<&'a Env> {
+    for uri in resolution_path.iter() {
+      let env = client.get_env_by_uri(uri);
+  
+      if env.is_some() {
+        return env;
+      }
+    }
+  
+    return None;
+}
+  


### PR DESCRIPTION
Closes: https://github.com/polywrap/rust-client/issues/79
Implemented the `getEnvFromResolutionPath` util function in core lib.
Using the `getEnvFromResolutionPath` in the client to fetch the appropriate env for the loaded wrapper.