### PR TITLE
Subinvoke resolution context

### DIFF
--- a/packages/client/src/client.rs
+++ b/packages/client/src/client.rs
@@ -139,7 +139,7 @@ impl Invoker for PolywrapClient {
         resolution_context.track_step(UriResolutionStep {
             source_uri: resolved_uri.clone(),
             result: match invoke_result.clone() {
-                Ok(_) => Ok(UriPackageOrWrapper::Uri(resolved_uri)),
+                Ok(_) => Ok(UriPackageOrWrapper::Uri(resolved_uri.clone())),
                 Err(e) => Err(Error::InvokeError(e.to_string())),
             },
             description: Some("Client.invokeWrapper".to_string()),

--- a/packages/client/src/client.rs
+++ b/packages/client/src/client.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use polywrap_core::{
     client::{Client, ClientConfig},
@@ -127,14 +127,17 @@ impl Invoker for PolywrapClient {
         };
 
         let invoke_context = resolution_context.create_sub_context();
+        let invoke_context = Arc::new(Mutex::new(invoke_context));
 
         let subinvoker = Arc::new(Subinvoker::new(
             Arc::new(self.clone()),
-            invoke_context,
+            invoke_context.clone(),
         ));
 
         let invoke_result = wrapper
             .invoke(subinvoker.clone(), uri, method, args, env, None);
+
+        let invoke_context = invoke_context.lock().unwrap();
 
         resolution_context.track_step(UriResolutionStep {
             source_uri: resolved_uri.clone(),
@@ -143,7 +146,7 @@ impl Invoker for PolywrapClient {
                 Err(e) => Err(Error::InvokeError(e.to_string())),
             },
             description: Some("Client.invokeWrapper".to_string()),
-            sub_history: Some(subinvoker.get_history())
+            sub_history: Some(invoke_context.get_history().clone())
         });
 
         invoke_result.map_err(|e| Error::InvokeError(e.to_string()))

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(trait_upcasting)]
 pub mod client;
+pub mod subinvoker;
 
 pub use polywrap_client_builder as builder;
 pub use polywrap_core as core;

--- a/packages/client/src/subinvoker.rs
+++ b/packages/client/src/subinvoker.rs
@@ -1,0 +1,47 @@
+use std::sync::{RwLock, Arc};
+
+use polywrap_core::{
+  resolvers::uri_resolution_context::{UriResolutionContext, UriResolutionStep}, 
+  invoker::Invoker, env::Env, error::Error, uri::Uri, interface_implementation::InterfaceImplementations
+};
+
+pub struct Subinvoker {
+  pub invoke_context: RwLock<UriResolutionContext>,
+  invoker: Arc<dyn Invoker>,
+}
+
+impl Subinvoker {
+  pub fn new(
+      invoker: Arc<dyn Invoker>,
+      invoke_context: UriResolutionContext,
+  ) -> Self {
+      Self {
+          invoker,
+          invoke_context: RwLock::new(invoke_context),
+      }
+  }
+
+  pub fn get_history(&self) -> Vec<UriResolutionStep> {
+      self.invoke_context.read().unwrap().get_history().clone()
+  }
+}
+
+impl Invoker for Subinvoker {
+  fn invoke_raw(
+      &self,
+      uri: &Uri,
+      method: &str,
+      args: Option<&[u8]>,
+      env: Option<&Env>,
+      _: Option<&mut UriResolutionContext>,
+  ) -> Result<Vec<u8>, Error> {
+      let mut context = self.invoke_context.write().unwrap();
+      self.invoker.invoke_raw(uri, method, args, env, Some(&mut context))
+  }
+  fn get_implementations(&self, uri: &Uri) -> Result<Vec<Uri>, Error> {
+      self.invoker.get_implementations(uri)
+  }
+  fn get_interfaces(&self) -> Option<InterfaceImplementations> {
+      self.invoker.get_interfaces()
+  }
+}

--- a/packages/client/src/subinvoker.rs
+++ b/packages/client/src/subinvoker.rs
@@ -1,13 +1,13 @@
 use std::sync::{RwLock, Arc};
 
 use polywrap_core::{
-  resolvers::uri_resolution_context::{UriResolutionContext, UriResolutionStep}, 
-  invoker::Invoker, env::Env, error::Error, uri::Uri, interface_implementation::InterfaceImplementations
+    resolvers::uri_resolution_context::{UriResolutionContext, UriResolutionStep}, 
+    invoker::Invoker, env::Env, error::Error, uri::Uri, interface_implementation::InterfaceImplementations
 };
 
 pub struct Subinvoker {
-  pub invoke_context: RwLock<UriResolutionContext>,
-  invoker: Arc<dyn Invoker>,
+    pub invoke_context: RwLock<UriResolutionContext>,
+    invoker: Arc<dyn Invoker>,
 }
 
 impl Subinvoker {
@@ -27,21 +27,21 @@ impl Subinvoker {
 }
 
 impl Invoker for Subinvoker {
-  fn invoke_raw(
-      &self,
-      uri: &Uri,
-      method: &str,
-      args: Option<&[u8]>,
-      env: Option<&Env>,
-      _: Option<&mut UriResolutionContext>,
-  ) -> Result<Vec<u8>, Error> {
-      let mut context = self.invoke_context.write().unwrap();
-      self.invoker.invoke_raw(uri, method, args, env, Some(&mut context))
-  }
-  fn get_implementations(&self, uri: &Uri) -> Result<Vec<Uri>, Error> {
-      self.invoker.get_implementations(uri)
-  }
-  fn get_interfaces(&self) -> Option<InterfaceImplementations> {
-      self.invoker.get_interfaces()
-  }
+    fn invoke_raw(
+        &self,
+        uri: &Uri,
+        method: &str,
+        args: Option<&[u8]>,
+        env: Option<&Env>,
+        _: Option<&mut UriResolutionContext>,
+    ) -> Result<Vec<u8>, Error> {
+        let mut context = self.invoke_context.write().unwrap();
+        self.invoker.invoke_raw(uri, method, args, env, Some(&mut context))
+    }
+    fn get_implementations(&self, uri: &Uri) -> Result<Vec<Uri>, Error> {
+        self.invoker.get_implementations(uri)
+    }
+    fn get_interfaces(&self) -> Option<InterfaceImplementations> {
+        self.invoker.get_interfaces()
+    }
 }

--- a/packages/client/tests/test_uri_resolvers.rs
+++ b/packages/client/tests/test_uri_resolvers.rs
@@ -8,7 +8,6 @@ use polywrap_client::resolvers::uri_resolver_wrapper::UriResolverWrapper;
 
 use polywrap_client::core::{
     resolvers::{
-        resolver_with_history::ResolverWithHistory,
         uri_resolution_context::{UriPackageOrWrapper, UriResolutionContext},
     },
     uri::Uri,
@@ -17,6 +16,7 @@ use polywrap_core::client::ClientConfig;
 use polywrap_core::file_reader::SimpleFileReader;
 use polywrap_core::interface_implementation::InterfaceImplementations;
 use polywrap_core::resolvers::static_resolver::StaticResolver;
+use polywrap_core::resolvers::uri_resolver::UriResolver;
 use polywrap_resolvers::base_resolver::BaseResolver;
 use polywrap_resolvers::simple_file_resolver::FilesystemResolver;
 use polywrap_tests_utils::helpers::get_tests_path;
@@ -51,7 +51,7 @@ fn test_uri_resolver_wrapper() {
         UriResolverWrapper::new(Uri::try_from("wrap://ens/fs-resolver.polywrap.eth").unwrap());
     let client = PolywrapClient::new(config);
     let result =
-        uri_resolver_wrapper._try_resolve_uri(&wrapper_uri, Arc::new(client), &mut uri_resolution_context);
+        uri_resolver_wrapper.try_resolve_uri(&wrapper_uri, Arc::new(client), &mut uri_resolution_context);
 
     if result.is_err() {
         panic!("Error in try resolver uri: {:?}", result.err());

--- a/packages/core/src/resolvers/uri_resolution_context.rs
+++ b/packages/core/src/resolvers/uri_resolution_context.rs
@@ -95,7 +95,7 @@ impl UriResolutionContext {
         UriResolutionContext {
             resolving_uri_map: self.resolving_uri_map.clone(),
             resolution_path: vec![],
-            history: self.history.clone()
+            history: vec![]
         }
     }
 }

--- a/packages/resolvers/src/uri_resolver_wrapper.rs
+++ b/packages/resolvers/src/uri_resolver_wrapper.rs
@@ -2,114 +2,113 @@ use core::fmt;
 use std::sync::{Arc};
 
 use polywrap_core::{
-  resolvers::uri_resolution_context::{UriPackageOrWrapper, UriResolutionContext},
-  uri::Uri,
-  error::Error, package::WrapPackage, invoker::Invoker, 
+    resolvers::{uri_resolution_context::{UriPackageOrWrapper, UriResolutionContext, UriResolutionStep}, uri_resolver::UriResolver},
+    uri::Uri,
+    error::Error, invoker::Invoker, 
 };
 use polywrap_msgpack::{msgpack, decode};
-use polywrap_wasm::wasm_package::{WasmPackage};
+use polywrap_wasm::wasm_package::WasmPackage;
 use serde::{Serialize,Deserialize};
 
-use polywrap_core::{resolvers::resolver_with_history::ResolverWithHistory, resolvers::helpers::UriResolverExtensionFileReader};
+use polywrap_core::resolvers::helpers::UriResolverExtensionFileReader;
 
 pub struct UriResolverWrapper {
-  pub implementation_uri: Uri
+    pub implementation_uri: Uri
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MaybeUriOrManifest {
-  pub uri: Option<String>,
-  pub manifest: Option<Vec<u8>>,
+    pub uri: Option<String>,
+    pub manifest: Option<Vec<u8>>,
 }
 
 impl UriResolverWrapper {
-  pub fn new(implementation_uri: Uri) -> Self {
-    UriResolverWrapper { implementation_uri }
-  }
+    pub fn new(implementation_uri: Uri) -> Self {
+        UriResolverWrapper { implementation_uri }
+    }
 
-  fn try_resolve_uri_with_implementation(
-    &self,
-    uri: &Uri,
-    implementation_uri: &Uri,
-    invoker: &dyn Invoker,
-    resolution_context: &mut UriResolutionContext
-  ) -> Result<MaybeUriOrManifest, Error> {
-      let result = invoker.invoke_raw(
-          implementation_uri,
-          "tryResolveUri", 
-          Some(&msgpack!({
-            "authority": uri.authority.as_str(),
-            "path": uri.path.as_str(),
-          })), 
-          None, 
-          Some(resolution_context)
-      )?;
+    fn try_resolve_uri_with_implementation(
+        &self,
+        uri: &Uri,
+        implementation_uri: &Uri,
+        invoker: &dyn Invoker,
+        resolution_context: &mut UriResolutionContext
+    ) -> Result<MaybeUriOrManifest, Error> {
 
-      if result.is_empty() {
-        Ok(MaybeUriOrManifest {
-          uri: None,
-          manifest: None
-        })
-      } else {
-        Ok(decode::<MaybeUriOrManifest>(result.as_slice())?)
-      }
+        let mut resolver_extension_context = resolution_context.create_sub_context();
+        let result = invoker.invoke_raw(
+            implementation_uri,
+            "tryResolveUri", 
+            Some(&msgpack!({
+                "authority": uri.authority.as_str(),
+                "path": uri.path.as_str(),
+            })), 
+            None, 
+            Some(&mut resolver_extension_context)
+        );
+
+        resolution_context.track_step(UriResolutionStep {
+            source_uri: uri.clone(),
+            result: match result.clone() {
+                Ok(_) => Ok(UriPackageOrWrapper::Uri(implementation_uri.clone())),
+                Err(e) => Err(e),
+            },
+            description: Some(format!("ResolverExtension({implementation_uri})")),
+            sub_history: Some(resolver_extension_context.get_history().clone())
+        });
+
+        let result = result?;
+
+        if result.is_empty() {
+            Ok(MaybeUriOrManifest {
+                uri: None,
+                manifest: None
+            })
+        } else {
+            Ok(decode::<MaybeUriOrManifest>(result.as_slice())?)
+        }
   }
 }
 
-impl ResolverWithHistory for UriResolverWrapper {
-    fn _try_resolve_uri(
-      &self, 
-      uri: &Uri, 
-      invoker: Arc<dyn Invoker>, 
-      resolution_context: &mut UriResolutionContext
+impl UriResolver for UriResolverWrapper {
+    fn try_resolve_uri(
+        &self, 
+        uri: &Uri, 
+        invoker: Arc<dyn Invoker>, 
+        resolution_context: &mut UriResolutionContext
     ) ->  Result<UriPackageOrWrapper, Error> {
-      let result = self.try_resolve_uri_with_implementation(
-        uri, 
-        &self.implementation_uri, 
-        invoker.as_ref(), 
-        resolution_context
-      )?;
-      let file_reader = UriResolverExtensionFileReader::new(
-        self.implementation_uri.clone(),
-        uri.clone(),
-        invoker
-      );
+        let result = self.try_resolve_uri_with_implementation(
+            uri, 
+            &self.implementation_uri, 
+            invoker.as_ref(), 
+            resolution_context
+        )?;
 
-      if let Some(manifest) = result.manifest {
-          let package = WasmPackage::new(
-            Arc::new(file_reader),
-            Some(manifest),
-            None
-          );
-          let wrapper = package.create_wrapper()?;
-          return Ok(UriPackageOrWrapper::Wrapper(uri.clone(), wrapper));
-      }
-
-      let package = WasmPackage::new(
-        Arc::new(file_reader), None, None
-      );
-
-      if package.get_manifest(None).is_ok() {
-        return Ok(
-          UriPackageOrWrapper::Package(uri.clone(), 
-          Arc::new(package))
+        let file_reader = UriResolverExtensionFileReader::new(
+            self.implementation_uri.clone(),
+            uri.clone(),
+            invoker
         );
-      }
 
-      if let Some(uri) = result.uri {
-          return Ok(UriPackageOrWrapper::Uri(uri.try_into()?));
-      }
+        if let Some(manifest) = result.manifest {
+            let package = WasmPackage::new(
+                Arc::new(file_reader),
+                Some(manifest),
+                None
+            );
+            return Ok(UriPackageOrWrapper::Package(uri.clone(), Arc::new(package)));
+        }
 
-      Ok(UriPackageOrWrapper::Uri(uri.clone()))
-    }
+        if let Some(uri) = result.uri {
+            return Ok(UriPackageOrWrapper::Uri(uri.try_into()?));
+        }
 
-    fn get_step_description(&self, uri: &Uri) -> String {
-      format!("UriResolverWrapper - Implementation called: {}", uri.clone().uri)
+        Ok(UriPackageOrWrapper::Uri(uri.clone()))
     }
 }
 
 impl fmt::Debug for UriResolverWrapper {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-      write!(f, "UriResolverWrapper: {:?}", self.implementation_uri)
-  }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "UriResolverWrapper: {:?}", self.implementation_uri)
+    }
 }

--- a/packages/resolvers/src/uri_resolver_wrapper.rs
+++ b/packages/resolvers/src/uri_resolver_wrapper.rs
@@ -34,7 +34,6 @@ impl UriResolverWrapper {
         invoker: &dyn Invoker,
         resolution_context: &mut UriResolutionContext
     ) -> Result<MaybeUriOrManifest, Error> {
-
         let mut resolver_extension_context = resolution_context.create_sub_context();
         let result = invoker.invoke_raw(
             implementation_uri,


### PR DESCRIPTION
Here is the analogous PR in the JS client: https://github.com/polywrap/javascript-client/pull/3

This PR implements resolution context passing to subinvocations. This way, context can be tracked across all nested wrapper calls. This allows for full resolution history tracking, as well as preventing potential recursive resolutions when using resolver extension wrappers.

**Changes**:

- **UriResolutionContex.createSubContext():**  History is not passed to the sub context and is instead left to the parent to control how it integrates with the parent history.
- **Subinvoker:** A new client invoker wrapper structure used as the invoker passed to wrappers. This "Subinvoker" includes the resolution context into the subinvocation (unlike in the JS version where it is done through wrappers state in the wasm wrapper and through client override in the plugin wrapper. This will also be changed in the JS client to mimick the Rust version).
- **PolywrapClient:** instead of passing the resolution context to the load wrapper and invocation processes, seperate sub contexts are created for them. This allows for users to track the load and invocation processes separately