### PR TITLE
Abort handler implementation and removal of URI from wrapper.invoke

### DIFF
--- a/packages/client/src/build_abort_handler.rs
+++ b/packages/client/src/build_abort_handler.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use polywrap_core::uri::Uri;
+
+pub fn build_abort_handler(custom_abort_handler: Option<Arc<dyn Fn(Uri, String, String) + Send + Sync>>, uri: Uri, method: String) -> Box<dyn Fn(String) + Send + Sync> {
+  match custom_abort_handler {
+      Some(abort) => {
+          return Box::new(move |error_message: String| {
+              abort(uri.clone(), method.clone(), error_message)
+          })
+      },
+      None => {
+          Box::new(move |error_message: String| {
+              panic!(
+                  r#"Wrapper aborted execution.
+                  URI: {uri}  
+                  Method: {method}
+                  Message: {error_message}
+              "#
+              );
+          })
+      }
+  }
+}

--- a/packages/client/src/client.rs
+++ b/packages/client/src/client.rs
@@ -17,7 +17,7 @@ use polywrap_core::{
 use polywrap_msgpack::decode;
 use serde::de::DeserializeOwned;
 
-use crate::subinvoker::Subinvoker;
+use crate::{subinvoker::Subinvoker, build_abort_handler::build_abort_handler};
 
 #[derive(Clone, Debug)]
 pub struct PolywrapClient {
@@ -231,28 +231,6 @@ impl Client for PolywrapClient {
         });
 
         invoke_result
-    }
-
-}
-
-fn build_abort_handler(custom_abort_handler: Option<Arc<dyn Fn(Uri, String, String) + Send + Sync>>, uri: Uri, method: String) -> Box<dyn Fn(String) + Send + Sync> {
-    match custom_abort_handler {
-        Some(abort) => {
-            return Box::new(move |error_message: String| {
-                abort(uri.clone(), method.clone(), error_message)
-            })
-        },
-        None => {
-            Box::new(move |error_message: String| {
-                panic!(
-                    r#"Wrapper aborted execution.
-                    URI: {uri}  
-                    Method: {method}
-                    Message: {error_message}
-                "#
-                );
-            })
-        }
     }
 }
 

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(trait_upcasting)]
 pub mod client;
 pub mod subinvoker;
+pub mod build_abort_handler;
 
 pub use polywrap_client_builder as builder;
 pub use polywrap_core as core;

--- a/packages/core/src/client.rs
+++ b/packages/core/src/client.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::error::Error;
 use crate::invoker::Invoker;

--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
   ResolverError(String),
   #[error("`{0}`")]
   PluginError(String),
+  #[error("`{0}`")]
+  RuntimeError(String),
 }
 
 impl From<MsgpackError> for Error {

--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -12,8 +12,8 @@ pub enum Error {
   WrapperError(String),
   #[error("Failed to create wrapper: `{0}`")]
   WrapperCreateError(String),
-  #[error("Failed to invoke wrapper: `{0}`")]
-  InvokeError(String),
+  #[error("Failed to invoke wrapper at `{0}`, method `{1}`: `{2}`")]
+  InvokeError(String, String, String),
   #[error("Error loading wrapper: `{0}`")]
   LoadWrapperError(String),
   #[error("WasmWrapper error: `{0}`")]

--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
   WrapperError(String),
   #[error("Failed to create wrapper: `{0}`")]
   WrapperCreateError(String),
-  #[error("Failed to invoke wrapper at `{0}`, method `{1}`: `{2}`")]
+  #[error("Failed to invoke wrapper, uri: `{0}`, method: `{1}`: `{2}`")]
   InvokeError(String, String, String),
   #[error("Error loading wrapper: `{0}`")]
   LoadWrapperError(String),

--- a/packages/core/src/wrapper.rs
+++ b/packages/core/src/wrapper.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, fmt::Debug, any::Any};
 
-use crate::{error::Error, invoker::Invoker, uri::Uri, env::Env};
+use crate::{error::Error, invoker::Invoker, env::Env};
 pub enum Encoding {
     Base64,
     UTF8,
@@ -14,11 +14,11 @@ pub struct GetFileOptions {
 pub trait Wrapper: Send + Sync + Debug + Any {
     fn invoke(
         &self,
-        invoker: Arc<dyn Invoker>,
-        uri: &Uri,
         method: &str,
         args: Option<&[u8]>,
         env: Option<&Env>,
+        invoker: Arc<dyn Invoker>,
+        abort_handler: Option<Box<dyn Fn(String) + Send + Sync>>,
     ) -> Result<Vec<u8>, Error>;
     fn get_file(&self, options: &GetFileOptions) -> Result<Vec<u8>, Error>;
 }

--- a/packages/plugin/src/error.rs
+++ b/packages/plugin/src/error.rs
@@ -3,22 +3,8 @@ use polywrap_msgpack::error::MsgpackError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum PluginError {
-  #[error("`{0}`")]
-  ModuleError(String),
-
-  #[error("PluginWrapper: invocation exception encountered.\nuri: {uri:?}\nmethod: {method:?}\nargs: {args:?}\nexception: {exception:?}")]
+  #[error("PluginWrapper: invocation exception encountered.\nexception: {exception:?}")]
   InvocationError {
-    uri: String,
-    method: String,
-    args: String,
-    exception: String
-  },
-
-  #[error("Subinvocation exception encountered.\nuri: {uri:?}\nmethod: {method:?}\nargs: {args:?}\nexception: {exception:?}")]
-  SubinvocationError {
-    uri: String,
-    method: String,
-    args: String,
     exception: String
   },
 

--- a/packages/tests-utils/src/helpers.rs
+++ b/packages/tests-utils/src/helpers.rs
@@ -1,6 +1,6 @@
 use std::{path::{Path,PathBuf},sync::{Arc}, fmt::{Debug, Formatter}};
 
-use polywrap_core::{wrapper::{Wrapper, GetFileOptions},  invoker::Invoker, uri::Uri, env::Env, resolvers::uri_resolution_context::UriResolutionContext, package::WrapPackage};
+use polywrap_core::{wrapper::{Wrapper, GetFileOptions},  invoker::Invoker, env::Env, package::WrapPackage};
 use wrap_manifest_schemas::versions::WrapManifest;
 
 pub struct MockWrapper {

--- a/packages/tests-utils/src/helpers.rs
+++ b/packages/tests-utils/src/helpers.rs
@@ -55,11 +55,11 @@ impl WrapPackage for MockPackage {
 impl Wrapper for MockWrapper {
     fn invoke(
         &self,
-        _: Arc<dyn Invoker>,
-        _: &Uri,
         _: &str,
         _: Option< &[u8]>,
         _: Option<&Env>,
+        _: Arc<dyn Invoker>,
+        _: Option<Box<dyn Fn(String) + Send + Sync>>,
     ) ->  Result<Vec<u8>, polywrap_core::error::Error> {
         Ok(vec![2])
     }

--- a/packages/wasm/src/wasm_wrapper.rs
+++ b/packages/wasm/src/wasm_wrapper.rs
@@ -73,10 +73,6 @@ pub enum WrapperInvokeError {
     RuntimeError(String),
 }
 
-trait RuntimeAbortHandler: Send + Sync {
-    fn handle_abort(&self, message: String);
-}
-
 impl Wrapper for WasmWrapper {
     fn invoke(
         &self,
@@ -105,16 +101,16 @@ impl Wrapper for WasmWrapper {
         let abort_method = method.to_string();
         let abort_handler = Arc::new(abort_handler);
 
-        let abort = Box::new(move |msg: String| {
+        let abort = Box::new(move |error_message: String| {
             if let Some(abort_handler) = abort_handler.as_ref() {
                 // Use the abort handler if provided
-                abort_handler(msg.clone());
+                abort_handler(error_message);
             } else {
                 // Otherwise, panic since this is an unrecoverable error
                 panic!(
                     r#"WasmWrapper: Wasm module aborted execution.
                   Method: {abort_method}
-                  Message: {msg}.
+                  Message: {error_message}.
                 "#
                 );
             }

--- a/packages/wasm/src/wasm_wrapper.rs
+++ b/packages/wasm/src/wasm_wrapper.rs
@@ -4,7 +4,6 @@ use polywrap_core::env::Env;
 use polywrap_core::error::Error;
 use polywrap_core::file_reader::FileReader;
 use polywrap_core::invoker::Invoker;
-use polywrap_core::uri::Uri;
 use polywrap_core::wrapper::Encoding;
 use polywrap_core::wrapper::GetFileOptions;
 use polywrap_core::wrapper::Wrapper;
@@ -38,14 +37,14 @@ impl WasmWrapper {
 
     pub fn invoke_and_decode<T: DeserializeOwned>(
         &self,
-        invoker: Arc<dyn Invoker>,
-        uri: &Uri,
         method: &str,
         args: Option<&[u8]>,
         env: Option<&Env>,
+        invoker: Arc<dyn Invoker>,
+        abort_handler: Option<Box<dyn Fn(String) + Send + Sync>>,
     ) -> Result<T, Error> {
         let result = self
-            .invoke(invoker, uri, method, args, env)?;
+            .invoke(method, args, env, invoker, abort_handler)?;
 
         let result = decode(result.as_slice())?;
 
@@ -69,14 +68,23 @@ impl Debug for WasmWrapper {
     }
 }
 
+pub enum WrapperInvokeError {
+    WrapError(Error),
+    RuntimeError(String),
+}
+
+trait RuntimeAbortHandler: Send + Sync {
+    fn handle_abort(&self, message: String);
+}
+
 impl Wrapper for WasmWrapper {
     fn invoke(
         &self,
-        invoker: Arc<dyn Invoker>,
-        uri: &Uri,
         method: &str,
         args: Option<&[u8]>,
         env: Option<&Env>,
+        invoker: Arc<dyn Invoker>,
+        abort_handler: Option<Box<dyn Fn(String) + Send + Sync>>,
     ) -> Result<Vec<u8>, Error> {
         let args = match args {
             Some(args) => args.to_vec(),
@@ -94,21 +102,22 @@ impl Wrapper for WasmWrapper {
             Value::I32(env.len().try_into().unwrap()),
         ];
 
-        let abort_uri = uri.clone();
         let abort_method = method.to_string();
-        let abort_args = args.clone();
-        let abort_env = env.clone();
+        let abort_handler = Arc::new(abort_handler);
 
-        let abort = Box::new(move |msg| {
-            panic!(
-                r#"WasmWrapper: Wasm module aborted execution.
-              URI: {abort_uri}
-              Method: {abort_method}
-              Args: {abort_args:?}
-              Env: {abort_env:?}
-              Message: {msg}.
-            "#
-            );
+        let abort = Box::new(move |msg: String| {
+            if let Some(abort_handler) = abort_handler.as_ref() {
+                // Use the abort handler if provided
+                abort_handler(msg.clone());
+            } else {
+                // Otherwise, panic since this is an unrecoverable error
+                panic!(
+                    r#"WasmWrapper: Wasm module aborted execution.
+                  Method: {abort_method}
+                  Message: {msg}.
+                "#
+                );
+            }
         });
 
         let state = Arc::new(Mutex::new(State::new(invoker, abort.clone(), method, args, env)));
@@ -121,18 +130,22 @@ impl Wrapper for WasmWrapper {
         let state = state.lock().unwrap();
         if result {
             if state.invoke.result.is_none() {
-                abort("Invoke result is missing".to_string());
+                return Err(Error::RuntimeError(
+                    "Invoke result is missing".to_string(),
+                ));
             }
 
             Ok(state.invoke.result.as_ref().unwrap().to_vec())
         } else {
             if state.invoke.error.is_none() {
-                abort("Invoke error is missing".to_string());
+                Err(Error::RuntimeError(
+                    "Invoke error is missing".to_string(),
+                ))
+            } else {
+                Err(Error::WrapperError(
+                    state.invoke.error.as_ref().unwrap().to_string(),
+                ))
             }
-
-            Err(Error::WrapperError(
-                state.invoke.error.as_ref().unwrap().to_string(),
-            ))
         }
     }
 

--- a/packages/wasm/src/wasm_wrapper.rs
+++ b/packages/wasm/src/wasm_wrapper.rs
@@ -68,11 +68,6 @@ impl Debug for WasmWrapper {
     }
 }
 
-pub enum WrapperInvokeError {
-    WrapError(Error),
-    RuntimeError(String),
-}
-
 impl Wrapper for WasmWrapper {
     fn invoke(
         &self,

--- a/packages/wasm/tests/test_runtime.rs
+++ b/packages/wasm/tests/test_runtime.rs
@@ -28,31 +28,19 @@ impl MockInvoker {
     fn invoke_wrapper_raw(
       &self,
       wrapper: Arc<dyn Wrapper>,
-      uri: &Uri,
+      _: &Uri,
       method: &str,
       args: Option<&[u8]>,
       env: Option<&Env>,
-      resolution_context: Option<&mut UriResolutionContext>
+      _: Option<&mut UriResolutionContext>
   ) -> Result<Vec<u8>, Error> {
-      let result = wrapper.invoke(
-          Arc::new(self.clone()),
-          uri,
+      wrapper.invoke(
           method,
           args,
           env,
-          resolution_context
-      );
-
-      if result.is_err() {
-          return Err(Error::InvokeError(format!(
-              "Failed to invoke wrapper: {}",
-              result.err().unwrap()
-          )));
-      };
-
-      let result = result.unwrap();
-
-      Ok(result)    
+          Arc::new(self.clone()),
+          None,
+      )
   }
 }
 
@@ -65,23 +53,14 @@ impl Invoker for MockInvoker {
         env: Option<&Env>,
         resolution_context: Option<&mut UriResolutionContext>,
     ) -> Result<Vec<u8>, Error> {
-        let invoke_result = self.clone().invoke_wrapper_raw(
+        self.clone().invoke_wrapper_raw(
             Arc::new(self.wrapper.clone()),
             uri,
             method,
             args,
             env,
             resolution_context,
-        );
-
-        if invoke_result.is_err() {
-            return Err(Error::InvokeError(format!(
-                "Failed to invoke wrapper: {}",
-                invoke_result.err().unwrap()
-            )));
-        };
-
-        Ok(invoke_result.unwrap())
+        )
     }
 
     fn get_implementations(&self, _uri: &Uri) -> Result<Vec<Uri>, Error> {


### PR DESCRIPTION
The goal of this PR is to decouple abort handling and URI from the wrapper runtime.
- URI has been removed from the wrapper.invoke function (it was used just for the abort message)
- Abort handler can now be provided to the wrapper.invoke function which will get called in case of an unrecoverable exception
The abort handler allows the client to handle the abort logic instead of leaving it to the individual wrapper runtime implementations. This gives more power to the client, it allows it to standardize abort logic across all wrappers and, in the future, it can allow users to customize the abort logic (by providing a custom abort handler).

**Other notable changes:** 

- Decode result errors are now MsgpackError instead of InvokeError
- Failing to resolve wrapper (uri not found) is now a ResolutionError instead of InvokeError
- InvokeError now contains the URI and method
- Removed PluginError::ModuleError and PluginError::SubinvocationError as they are not being used
- Removed URI, method and args from PluginError::InvocationError. URI and method can/will be included in the parent InvokeError, while args I feel are not a good thing to output by default because they could contain sensitive data. That could be changed by the user in the future when we allow them to provide a custom abort handler (Or if the user "inherits" the PolywrapClient and overrides the `invoke_wrapper_raw` method).