### PR TITLE
Split core Client trait into Invoker + WrapLoader + WrapInvoker + UriResolverHandler

### DIFF
--- a/packages/client/src/subinvoker.rs
+++ b/packages/client/src/subinvoker.rs
@@ -40,4 +40,7 @@ impl Invoker for Subinvoker {
     fn get_interfaces(&self) -> Option<InterfaceImplementations> {
         self.invoker.get_interfaces()
     }
+    fn get_env_by_uri(&self, uri: &Uri) -> Option<&Env> {
+        self.invoker.get_env_by_uri(uri)
+    }
 }

--- a/packages/core/src/client.rs
+++ b/packages/core/src/client.rs
@@ -1,13 +1,12 @@
 use std::sync::Arc;
 
-use crate::error::Error;
-use crate::invoker::Invoker;
-use crate::resolvers::uri_resolution_context::UriResolutionContext;
 use crate::uri::Uri;
 use crate::interface_implementation::InterfaceImplementations;
 use crate::resolvers::uri_resolver::{UriResolverHandler, UriResolver};
-use crate::env::{Envs, Env};
-use crate::wrapper::Wrapper;
+use crate::env::Envs;
+use crate::invoker::Invoker;
+use crate::wrap_invoker::WrapInvoker;
+use crate::wrap_loader::WrapLoader;
 
 #[derive(Clone,Debug)]
 pub struct UriRedirect {
@@ -28,20 +27,4 @@ pub struct ClientConfig {
   pub interfaces: Option<InterfaceImplementations>
 }
 
-pub trait Client: Invoker + UriResolverHandler {
-  fn get_env_by_uri(&self, uri: &Uri) -> Option<&Env>;
-  fn load_wrapper(
-    &self,
-    uri: &Uri,
-    resolution_context: Option<&mut UriResolutionContext>,
-  ) -> Result<Arc<dyn Wrapper>, Error>;
-  fn invoke_wrapper_raw(
-    &self,
-    wrapper: &dyn Wrapper,
-    uri: &Uri,
-    method: &str,
-    args: Option<&[u8]>,
-    env: Option<&Env>,
-    resolution_context: Option<&mut UriResolutionContext>,
-) -> Result<Vec<u8>, Error>;
-}
+pub trait Client: Invoker + WrapLoader + WrapInvoker + UriResolverHandler {}

--- a/packages/core/src/invoker.rs
+++ b/packages/core/src/invoker.rs
@@ -1,7 +1,7 @@
 use crate::{
-    error::Error, uri::Uri, resolvers::uri_resolution_context::UriResolutionContext, env::{Env}, interface_implementation::InterfaceImplementations,
+    error::Error, uri::Uri, resolvers::uri_resolution_context::UriResolutionContext, env::Env, 
+    interface_implementation::InterfaceImplementations,
 };
-
 pub trait Invoker: Send + Sync {
     fn invoke_raw(
         &self,
@@ -13,4 +13,5 @@ pub trait Invoker: Send + Sync {
     ) -> Result<Vec<u8>, Error>;
     fn get_implementations(&self, uri: &Uri) -> Result<Vec<Uri>, Error>;
     fn get_interfaces(&self) -> Option<InterfaceImplementations>;
+    fn get_env_by_uri(&self, uri: &Uri) -> Option<&Env>;
 }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -3,6 +3,8 @@ pub mod error;
 pub mod client;
 pub mod wrapper;
 pub mod invoker;
+pub mod wrap_loader;
+pub mod wrap_invoker;
 pub mod redirects;
 pub mod package;
 pub mod file_reader;

--- a/packages/core/src/wrap_invoker.rs
+++ b/packages/core/src/wrap_invoker.rs
@@ -1,0 +1,13 @@
+use crate::{resolvers::uri_resolution_context::UriResolutionContext, error::Error, wrapper::Wrapper, uri::Uri, env::Env};
+
+pub trait WrapInvoker: Send + Sync {
+  fn invoke_wrapper_raw(
+      &self,
+      wrapper: &dyn Wrapper,
+      uri: &Uri,
+      method: &str,
+      args: Option<&[u8]>,
+      env: Option<&Env>,
+      resolution_context: Option<&mut UriResolutionContext>,
+  ) -> Result<Vec<u8>, Error>;
+}

--- a/packages/core/src/wrap_loader.rs
+++ b/packages/core/src/wrap_loader.rs
@@ -1,0 +1,11 @@
+use std::sync::Arc;
+
+use crate::{resolvers::uri_resolution_context::UriResolutionContext, error::Error, wrapper::Wrapper, uri::Uri};
+
+pub trait WrapLoader: Send + Sync {
+  fn load_wrapper(
+      &self,
+      uri: &Uri,
+      resolution_context: Option<&mut UriResolutionContext>,
+  ) -> Result<Arc<dyn Wrapper>, Error>;
+}

--- a/packages/native/src/client.rs
+++ b/packages/native/src/client.rs
@@ -93,7 +93,7 @@ impl FFIClient {
             &_decoded_env
         });
 
-        self.inner_client.invoke_wrapper_raw(wrapper.0.clone(), uri.as_ref(), method, args, env, None)
+        self.inner_client.invoke_wrapper_raw(&*wrapper.0.clone(), uri.as_ref(), method, args, env, None)
     }
 
     pub fn load_wrapper(&self, uri: Arc<Uri>) -> Result<Arc<FFIWrapper>, Error> {

--- a/packages/wasm/tests/test_runtime.rs
+++ b/packages/wasm/tests/test_runtime.rs
@@ -71,6 +71,10 @@ impl Invoker for MockInvoker {
         let i = HashMap::new();
         Some(i)
     }
+
+    fn get_env_by_uri(&self, _: &Uri) -> Option<&Env> {
+        None
+    }
 }
 
 #[test]


### PR DESCRIPTION
The Client trait is now defined as follows:
```rust
pub trait Client: Invoker + WrapLoader + WrapInvoker + UriResolverHandler {}
```
The idea being that developers can now define type constraints based only on the traits that they need.
E.g. 
- if all function needs is the ability to invoke a URI then it only needs an invoker.
- if it needs to be able to load and invoke wrappers then it needs a WrapLoader + WrapInvoker

The component traits of the Client are defined as follows:
```rust
pub trait Invoker: Send + Sync {
    fn invoke_raw(
        &self,
        uri: &Uri,
        method: &str,
        args: Option<&[u8]>,
        env: Option<&Env>,
        resolution_context: Option<&mut UriResolutionContext>,
    ) -> Result<Vec<u8>, Error>;
    fn get_implementations(&self, uri: &Uri) -> Result<Vec<Uri>, Error>;
    fn get_interfaces(&self) -> Option<InterfaceImplementations>;
    fn get_env_by_uri(&self, uri: &Uri) -> Option<&Env>;
}
```
```rust
pub trait WrapLoader: Send + Sync {
  fn load_wrapper(
      &self,
      uri: &Uri,
      resolution_context: Option<&mut UriResolutionContext>,
  ) -> Result<Arc<dyn Wrapper>, Error>;
}
```
```rust
pub trait WrapInvoker: Send + Sync {
  fn invoke_wrapper_raw(
      &self,
      wrapper: &dyn Wrapper,
      uri: &Uri,
      method: &str,
      args: Option<&[u8]>,
      env: Option<&Env>,
      resolution_context: Option<&mut UriResolutionContext>,
  ) -> Result<Vec<u8>, Error>;
}
```
```rust
pub trait UriResolverHandler {
  fn try_resolve_uri(
      &self,
      uri: &Uri,
      resolution_context: Option<&mut UriResolutionContext>,
  ) -> Result<UriPackageOrWrapper, Error>;
}
```

Additionally, `get_env_by_uri` has been moved from the Client trait into the Invoker trait. It makes sense that anyone with access to invoker can also get env's just like interfaces and implementations. This is especially true in the full version of WRAP 0.2 where getting those 3 is only possible through invocations.