### PR TITLE
Deserializing with serde bytes in UriResolverExtensionFileReader

### DIFF
--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -14,3 +14,4 @@ wrap_manifest_schemas.workspace = true
 polywrap_msgpack.workspace = true
 serde.workspace = true
 jsonschema.workspace = true
+serde_bytes.workspace = true

--- a/packages/core/src/resolution/helpers.rs
+++ b/packages/core/src/resolution/helpers.rs
@@ -8,6 +8,7 @@ use crate::{
     interface_implementation::InterfaceImplementations, client::Client, invoker::Invoker
 };
 use polywrap_msgpack::{msgpack};
+use serde_bytes::ByteBuf;
 
 fn combine_paths(a: &str, b: &str) -> String {
   let mut a = a.to_string();
@@ -65,8 +66,8 @@ impl FileReader for UriResolverExtensionFileReader {
             None
         )?;
         
-        let result: Vec<u8> = polywrap_msgpack::decode(&result)?;
-        Ok(result)
+        let result: ByteBuf = polywrap_msgpack::decode(&result)?;
+        Ok(result.into_vec())
     }
 }
 


### PR DESCRIPTION
Should finally enable us to use resolver extension wraps (ipfs, ens, fs) with the Rust client 
