### PR TITLE
add e2e ipfs invoke test to FFI package

### DIFF
--- a/packages/native/Cargo.toml
+++ b/packages/native/Cargo.toml
@@ -24,6 +24,7 @@ uniffi = { version = "0.23.0", features = [ "build" ] }
 
 [dev-dependencies]
 polywrap_tests_utils.workspace = true
+polywrap_client_default_config.workspace = true
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/packages/native/src/client.rs
+++ b/packages/native/src/client.rs
@@ -166,6 +166,9 @@ impl Invoker for FFIClient {
 #[cfg(test)]
 mod test {
     use std::{collections::HashMap, sync::Arc};
+    use polywrap_client::builder::types::ClientConfigHandler;
+    use polywrap_client::client::PolywrapClient;
+    use polywrap_client::msgpack::msgpack;
 
     use polywrap_tests_utils::mocks::{get_mock_client, get_mock_invoker, get_mock_wrapper};
 
@@ -228,5 +231,28 @@ mod test {
 
         let response = ffi_client.get_env_by_uri(uri);
         assert_eq!(response.unwrap(), [4, 8]);
+    }
+
+    #[test]
+    fn ffi_invoke_raw_real() {
+        let config = polywrap_client_default_config::build().build();
+        let client = Arc::from(PolywrapClient::new(config));
+        let ffi_client = FFIClient::new(client.clone());
+
+        const SUBINVOKE_WRAP_URI: &str = "wrap://ipfs/Qmf7jukQhTQekdSgKfdnFtB6ERTN6V7aT4oYpzesDyr2cS";
+        let uri = Arc::new(FFIUri::from_string(SUBINVOKE_WRAP_URI));
+
+        let result = ffi_client.invoke_raw(
+            uri.clone(),
+            "add",
+            Some(msgpack!({
+                "a": 2,
+                "b": 40
+            })),
+            None,
+            None,
+        ).unwrap();
+
+        assert_eq!(result, msgpack!(42));
     }
 }


### PR DESCRIPTION
This PR adds a test that invokes a real wrapper on ipfs using the FFI client