### PR TITLE
Implemented a more complete set of traits for Uri

### DIFF
--- a/packages/core/src/error.rs
+++ b/packages/core/src/error.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 
 use polywrap_msgpack_serde::Error as MsgpackError;
-use polywrap_uri::UriParseError;
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     #[error("Error parsing URI: `{0}`")]
-    UriParseError(String),
+    UriParseError(#[from] polywrap_uri::ParseError),
     #[error("`{0}`\nResolution Stack: `{1:#?}`")]
     RedirectsError(String, HashMap<String, String>),
     #[error("`{0}`")]
@@ -37,10 +36,4 @@ pub enum Error {
     RuntimeError(String),
     #[error("`{0}`")]
     OtherError(String),
-}
-
-impl From<UriParseError> for Error {
-    fn from(e: UriParseError) -> Self {
-        Error::UriParseError(e.to_string())
-    }
 }

--- a/packages/native/src/error.rs
+++ b/packages/native/src/error.rs
@@ -46,9 +46,9 @@ pub enum FFIError {
 impl From<polywrap_client::core::error::Error> for FFIError {
     fn from(value: polywrap_client::core::error::Error) -> Self {
         match value {
-            polywrap_client::core::error::Error::UriParseError(err) => {
-                FFIError::UriParseError { err }
-            }
+            polywrap_client::core::error::Error::UriParseError(err) => FFIError::UriParseError {
+                err: err.to_string(),
+            },
             polywrap_client::core::error::Error::RedirectsError(err, resolution_stack) => {
                 FFIError::RedirectsError {
                     err,
@@ -78,7 +78,9 @@ impl From<polywrap_client::core::error::Error> for FFIError {
             }
             polywrap_client::core::error::Error::MsgpackError(err) => {
                 // let error
-                FFIError::MsgpackError { err: err.to_string() }
+                FFIError::MsgpackError {
+                    err: err.to_string(),
+                }
             }
             polywrap_client::core::error::Error::ManifestError(err) => {
                 FFIError::ManifestError { err }
@@ -101,9 +103,9 @@ impl From<polywrap_client::core::error::Error> for FFIError {
 impl From<FFIError> for polywrap_client::core::error::Error {
     fn from(value: FFIError) -> Self {
         match value {
-            FFIError::UriParseError { err } => {
-                polywrap_client::core::error::Error::UriParseError(err)
-            }
+            FFIError::UriParseError { err } => polywrap_client::core::error::Error::UriParseError(
+                polywrap_client::core::uri::ParseError(err),
+            ),
             FFIError::RedirectsError {
                 err,
                 resolution_stack,


### PR DESCRIPTION
**Main change:**
- Implemented `FromStr` for Uri for more idiomatic string parsing
**Other changes:**
- Added `Deserialize` to Uri
- Renamed `UriParseError` to `ParseError`
- Implemented `Error` for `ParseError`
 