### PR TITLE
Applied more idiomatic URI parsing

### DIFF
--- a/packages/client/tests/it/wrap_features/env_with_invoke.rs
+++ b/packages/client/tests/it/wrap_features/env_with_invoke.rs
@@ -6,7 +6,7 @@ use polywrap_core::file_reader::SimpleFileReader;
 use polywrap_core::macros::uri;
 use polywrap_core::resolution::uri_resolution_context::UriPackageOrWrapper;
 use polywrap_core::resolution::uri_resolver::UriResolver;
-use polywrap_msgpack_serde::{to_vec};
+use polywrap_msgpack_serde::to_vec;
 use polywrap_resolvers::base_resolver::BaseResolver;
 use polywrap_resolvers::recursive_resolver::RecursiveResolver;
 use polywrap_resolvers::resolver_vec;
@@ -20,12 +20,14 @@ fn get_env_wrapper_uri() -> Uri {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
 
-    Uri::try_from(format!("fs/{path}/env-type/00-main/implementations/rs")).unwrap()
+    format!("fs/{path}/env-type/00-main/implementations/rs")
+        .parse()
+        .unwrap()
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct EnvObject {
-    pub prop: String
+    pub prop: String,
 }
 
 #[allow(non_snake_case)]
@@ -56,7 +58,9 @@ fn get_default_env() -> Env {
         optBool: None,
         en: 0,
         optEnum: None,
-        object: EnvObject { prop: "object string".to_string() },
+        object: EnvObject {
+            prop: "object string".to_string(),
+        },
         optObject: None,
         array: vec![32, 23],
     }
@@ -245,7 +249,10 @@ fn env_can_be_registered_for_any_uri_in_resolution_path() {
         let client = {
             let mut envs: HashMap<Uri, Vec<u8>> = HashMap::new();
 
-            envs.insert(wrapper_uri.clone(), polywrap_msgpack_serde::to_vec(&env).unwrap());
+            envs.insert(
+                wrapper_uri.clone(),
+                polywrap_msgpack_serde::to_vec(&env).unwrap(),
+            );
 
             let resolvers = HashMap::from([(
                 redirect_from_uri.clone(),

--- a/packages/client/tests/it/wrap_features/env_with_subinvoke.rs
+++ b/packages/client/tests/it/wrap_features/env_with_subinvoke.rs
@@ -5,7 +5,7 @@ use polywrap_core::client::ClientConfig;
 use polywrap_core::file_reader::SimpleFileReader;
 use polywrap_core::macros::uri;
 use polywrap_core::resolution::uri_resolution_context::UriPackageOrWrapper;
-use polywrap_msgpack_serde::{to_vec};
+use polywrap_msgpack_serde::to_vec;
 use polywrap_resolvers::base_resolver::BaseResolver;
 use polywrap_resolvers::simple_file_resolver::FilesystemResolver;
 use polywrap_resolvers::static_resolver::StaticResolver;
@@ -19,27 +19,27 @@ fn get_subinvoker_uri() -> Uri {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
 
-    Uri::try_from(format!(
-        "fs/{path}/env-type/01-subinvoker/implementations/rs"
-    ))
-    .unwrap()
+    format!("fs/{path}/env-type/01-subinvoker/implementations/rs")
+        .parse()
+        .unwrap()
 }
 
 fn get_subinvoker_with_env_uri() -> Uri {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
 
-    Uri::try_from(format!(
-        "fs/{path}/env-type/02-subinvoker-with-env/implementations/rs"
-    ))
-    .unwrap()
+    format!("fs/{path}/env-type/02-subinvoker-with-env/implementations/rs")
+        .parse()
+        .unwrap()
 }
 
 fn get_subinvoked_uri() -> Uri {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
 
-    Uri::try_from(format!("fs/{path}/env-type/00-main/implementations/rs")).unwrap()
+    format!("fs/{path}/env-type/00-main/implementations/rs")
+        .parse()
+        .unwrap()
 }
 
 fn get_default_env() -> Env {

--- a/packages/client/tests/it/wrap_features/interface_implementation.rs
+++ b/packages/client/tests/it/wrap_features/interface_implementation.rs
@@ -1,5 +1,5 @@
 use polywrap_client::client::PolywrapClient;
-use polywrap_client::core::{interface_implementation::InterfaceImplementations, uri::Uri};
+use polywrap_client::core::interface_implementation::InterfaceImplementations;
 
 use polywrap_core::client::ClientConfig;
 use polywrap_core::file_reader::SimpleFileReader;
@@ -27,14 +27,13 @@ struct Args {
 fn test_interface_implementation() {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let implementation_uri = Uri::try_from(format!(
-        "fs/{path}/interface-invoke/01-implementation/implementations/as"
-    ))
-    .unwrap();
-    let wrapper_uri = Uri::try_from(format!(
-        "fs/{path}/interface-invoke/02-wrapper/implementations/as"
-    ))
-    .unwrap();
+    let implementation_uri =
+        format!("fs/{path}/interface-invoke/01-implementation/implementations/as")
+            .parse()
+            .unwrap();
+    let wrapper_uri = format!("fs/{path}/interface-invoke/02-wrapper/implementations/as")
+        .parse()
+        .unwrap();
 
     let mut interfaces: InterfaceImplementations = HashMap::new();
     interfaces.insert(

--- a/packages/client/tests/it/wrap_features/subinvoke.rs
+++ b/packages/client/tests/it/wrap_features/subinvoke.rs
@@ -25,12 +25,12 @@ fn subinvoke_test() {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
 
-    let invoke_uri =
-        Uri::try_from(format!("fs/{path}/subinvoke/01-invoke/implementations/rs")).unwrap();
-    let subinvoke_uri = Uri::try_from(format!(
-        "fs/{path}/subinvoke/00-subinvoke/implementations/rs"
-    ))
-    .unwrap();
+    let invoke_uri = format!("fs/{path}/subinvoke/01-invoke/implementations/rs")
+        .parse()
+        .unwrap();
+    let subinvoke_uri = format!("fs/{path}/subinvoke/00-subinvoke/implementations/rs")
+        .parse()
+        .unwrap();
 
     let mut resolvers = HashMap::new();
     resolvers.insert(

--- a/packages/client/tests/it/wrap_types/asyncify.rs
+++ b/packages/client/tests/it/wrap_types/asyncify.rs
@@ -65,7 +65,9 @@ struct SetDataWithManyArgsArgs {
 fn get_client_and_uri() -> (PolywrapClient, Uri) {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/asyncify/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/asyncify/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     let memory_storage_plugin = MemoryStoragePlugin { value: 0 };
     let memory_storage_plugin_package: PluginPackage = memory_storage_plugin.into();

--- a/packages/client/tests/it/wrap_types/bigint.rs
+++ b/packages/client/tests/it/wrap_types/bigint.rs
@@ -10,7 +10,9 @@ use crate::wrap_types::get_client;
 fn get_client_and_uri() -> (PolywrapClient, Uri) {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/bigint-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/bigint-type/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     (get_client(None), uri)
 }

--- a/packages/client/tests/it/wrap_types/bignumber.rs
+++ b/packages/client/tests/it/wrap_types/bignumber.rs
@@ -23,7 +23,9 @@ struct ArgsObject {
 fn get_client_and_uri() -> (PolywrapClient, Uri) {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/bignumber-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/bignumber-type/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     (get_client(None), uri)
 }

--- a/packages/client/tests/it/wrap_types/bytes.rs
+++ b/packages/client/tests/it/wrap_types/bytes.rs
@@ -1,4 +1,3 @@
-use polywrap_client::core::uri::Uri;
 use polywrap_msgpack_serde::to_vec;
 use polywrap_tests_utils::helpers::get_tests_path;
 use serde::{Deserialize, Serialize};
@@ -21,7 +20,9 @@ struct Args {
 fn bytes_method() {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/bytes-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/bytes-type/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     let client = get_client(None);
     let args = BytesMethodArgs {

--- a/packages/client/tests/it/wrap_types/enum.rs
+++ b/packages/client/tests/it/wrap_types/enum.rs
@@ -9,7 +9,9 @@ use super::get_client;
 fn get_client_and_uri() -> (PolywrapClient, Uri) {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/enum-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/enum-type/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     (get_client(None), uri)
 }
@@ -68,9 +70,9 @@ fn method_one_panic_invalid_value() {
 #[derive(Serialize)]
 #[allow(unused)]
 pub enum EnumArg {
-  OPTION1,
-  OPTION2,
-  OPTION3
+    OPTION1,
+    OPTION2,
+    OPTION3,
 }
 
 #[derive(Serialize)]
@@ -80,7 +82,6 @@ struct MethodTwoArgs {
     optEnumArray: Option<u32>,
 }
 
-
 #[test]
 fn method_two_success() {
     let (client, uri) = get_client_and_uri();
@@ -88,10 +89,13 @@ fn method_two_success() {
         .invoke::<Vec<i32>>(
             &uri,
             "method2",
-            Some(&to_vec(&MethodTwoArgs {
-                enumArray: vec![EnumArg::OPTION1, EnumArg::OPTION1, EnumArg::OPTION3],
-                optEnumArray: None,
-            }).unwrap()),
+            Some(
+                &to_vec(&MethodTwoArgs {
+                    enumArray: vec![EnumArg::OPTION1, EnumArg::OPTION1, EnumArg::OPTION3],
+                    optEnumArray: None,
+                })
+                .unwrap(),
+            ),
             None,
             None,
         )

--- a/packages/client/tests/it/wrap_types/invalid_invokes.rs
+++ b/packages/client/tests/it/wrap_types/invalid_invokes.rs
@@ -1,5 +1,3 @@
-use polywrap_client::core::uri::Uri;
-use polywrap_client_builder::PolywrapClientConfig;
 use polywrap_msgpack_serde::to_vec;
 use polywrap_tests_utils::helpers::get_tests_path;
 use serde::Serialize;
@@ -40,7 +38,9 @@ use crate::wrap_types::get_client;
 fn invalid_test_case() {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/invalid-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/invalid-type/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     let client = get_client(None);
 

--- a/packages/client/tests/it/wrap_types/json.rs
+++ b/packages/client/tests/it/wrap_types/json.rs
@@ -16,7 +16,9 @@ struct StringifyArgs {
 fn get_client_and_uri() -> (PolywrapClient, Uri) {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/json-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/json-type/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     (get_client(None), uri)
 }

--- a/packages/client/tests/it/wrap_types/map.rs
+++ b/packages/client/tests/it/wrap_types/map.rs
@@ -38,7 +38,9 @@ pub struct CustomMap {
 fn get_client_and_uri() -> (PolywrapClient, Uri) {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{path}/map-type/implementations/rs")).unwrap();
+    let uri = format!("fs/{path}/map-type/implementations/rs")
+        .parse()
+        .unwrap();
     (get_client(None), uri)
 }
 
@@ -108,7 +110,9 @@ fn return_custom_map() {
         .invoke::<CustomMap>(
             &uri,
             "returnCustomMap",
-            Some(&polywrap_msgpack_serde::to_vec(&ArgsReturnCustomMap { foo: custom_map }).unwrap()),
+            Some(
+                &polywrap_msgpack_serde::to_vec(&ArgsReturnCustomMap { foo: custom_map }).unwrap(),
+            ),
             None,
             None,
         )

--- a/packages/client/tests/it/wrap_types/numbers.rs
+++ b/packages/client/tests/it/wrap_types/numbers.rs
@@ -1,5 +1,3 @@
-use polywrap_client::core::uri::Uri;
-use polywrap_client_builder::PolywrapClientConfig;
 use polywrap_msgpack_serde::to_vec;
 use polywrap_tests_utils::helpers::get_tests_path;
 use serde::Serialize;
@@ -16,7 +14,9 @@ use crate::wrap_types::get_client;
 fn numbers_test_case() {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/numbers-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/numbers-type/implementations/rs", path)
+        .parse()
+        .unwrap();
 
     let client = get_client(None);
 

--- a/packages/client/tests/it/wrap_types/object.rs
+++ b/packages/client/tests/it/wrap_types/object.rs
@@ -9,7 +9,9 @@ use super::get_client;
 fn get_client_and_uri() -> (PolywrapClient, Uri) {
     let test_path = get_tests_path().unwrap();
     let path = test_path.into_os_string().into_string().unwrap();
-    let uri = Uri::try_from(format!("fs/{}/object-type/implementations/rs", path)).unwrap();
+    let uri = format!("fs/{}/object-type/implementations/rs", path)
+        .parse()
+        .unwrap();
     (get_client(None), uri)
 }
 

--- a/packages/core/macros/src/lib.rs
+++ b/packages/core/macros/src/lib.rs
@@ -8,12 +8,9 @@ pub fn uri(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let input = parse_macro_input!(input as LitStr);
 
-    // Get the string value
-    let uri_str = input.value();
+    let parse_result = input.value().parse::<Uri>();
 
-    let uri_result = Uri::try_from(uri_str);
-
-    match uri_result {
+    match parse_result {
         Ok(uri) => {
             let authority = uri.authority();
             let path = uri.path();

--- a/packages/core/src/redirects.rs
+++ b/packages/core/src/redirects.rs
@@ -36,5 +36,5 @@ pub fn apply_redirects(uri: &Uri, redirects: &[UriRedirect]) -> Result<Uri, Erro
         }
     }
 
-    Ok(Uri::try_from(final_uri)?)
+    Ok(final_uri.parse()?)
 }

--- a/packages/core/src/resolution/uri_resolution_context.rs
+++ b/packages/core/src/resolution/uri_resolution_context.rs
@@ -79,7 +79,7 @@ impl UriResolutionContext {
     pub fn get_resolution_path(&self) -> Vec<Uri> {
         self.resolution_path
             .iter()
-            .map(|uri| Uri::try_from(uri.to_owned()).unwrap())
+            .map(|uri| uri.to_owned().parse().unwrap())
             .collect()
     }
 

--- a/packages/default-config/tests/it/fs.rs
+++ b/packages/default-config/tests/it/fs.rs
@@ -1,6 +1,5 @@
 use polywrap_client::client::PolywrapClient;
 use polywrap_client_default_config::SystemClientConfig;
-use polywrap_core::uri::Uri;
 use polywrap_msgpack_serde::to_vec;
 use polywrap_tests_utils::helpers::get_tests_path;
 use serde::Serialize;
@@ -21,7 +20,7 @@ fn sanity() {
 
     let result = client
         .invoke::<u32>(
-            &Uri::try_from(subinvoke_wrap_uri).unwrap(),
+            &subinvoke_wrap_uri.parse().unwrap(),
             "add",
             Some(&to_vec(&ArgsAdd { a: 2, b: 40 }).unwrap()),
             None,

--- a/packages/default-config/tests/it/http.rs
+++ b/packages/default-config/tests/it/http.rs
@@ -1,8 +1,7 @@
 use polywrap_client::client::PolywrapClient;
 use polywrap_client_default_config::SystemClientConfig;
-use polywrap_core::uri::Uri;
-use serde::Serialize;
 use polywrap_msgpack_serde::to_vec;
+use serde::Serialize;
 
 const URI: &str =
     "http/https://raw.githubusercontent.com/polywrap/client-readiness/main/wraps/public";
@@ -19,7 +18,7 @@ fn sanity() {
 
     let result = client
         .invoke::<u32>(
-            &Uri::try_from(URI).unwrap(),
+            &URI.parse().unwrap(),
             "i8Method",
             Some(
                 &to_vec(&Args {

--- a/packages/default-config/tests/it/ipfs.rs
+++ b/packages/default-config/tests/it/ipfs.rs
@@ -1,7 +1,6 @@
 use polywrap_client::client::PolywrapClient;
 use polywrap_client_builder::{PolywrapClientConfig, PolywrapClientConfigBuilder};
 use polywrap_client_default_config::{SystemClientConfig, Web3ClientConfig};
-use polywrap_core::uri::Uri;
 use polywrap_msgpack_serde::to_vec;
 
 use crate::fs::ArgsAdd;
@@ -18,7 +17,7 @@ fn sanity() {
     let client = PolywrapClient::new(config.into());
     let result = client
         .invoke::<u32>(
-            &Uri::try_from(SUBINVOKE_WRAP_URI).unwrap(),
+            &SUBINVOKE_WRAP_URI.parse().unwrap(),
             "add",
             Some(&to_vec(&ArgsAdd { a: 2, b: 40 }).unwrap()),
             None,

--- a/packages/native/src/resolvers/_static.rs
+++ b/packages/native/src/resolvers/_static.rs
@@ -26,7 +26,7 @@ impl FFIStaticUriResolver {
         let uri_map: Result<HashMap<Uri, UriPackageOrWrapper>, _> = uri_map
             .into_iter()
             .map(|(uri, variant)| {
-                Uri::try_from(uri)
+                uri.parse::<Uri>()
                     .map_err(|e| FFIError::UriParseError { err: e.to_string() })
                     .map(|uri| {
                         let uri_package_or_wrapper: UriPackageOrWrapper = variant.into();

--- a/packages/native/src/uri.rs
+++ b/packages/native/src/uri.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use polywrap_client::core::uri::Uri;
 
 #[derive(Clone, Debug, Hash, Eq)]
@@ -15,7 +17,7 @@ impl FFIUri {
     }
 
     pub fn from_string(uri: &str) -> Self {
-        FFIUri(Uri::try_from(uri).unwrap())
+        uri.parse().unwrap()
     }
 
     pub fn to_string_uri(&self) -> String {
@@ -71,6 +73,15 @@ impl std::fmt::Display for FFIUri {
     }
 }
 
+impl FromStr for FFIUri {
+    type Err = polywrap_client::core::error::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uri: Uri = s.try_into()?;
+        Ok(FFIUri(uri))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use polywrap_client::core::{macros::uri, uri::Uri};
@@ -94,11 +105,11 @@ mod test {
     pub fn ffi_uri_from_string() {
         let expected_uri = FFIUri::from_string("wrap://mock/a");
         let str_uri = "mock/a";
-        let uri = FFIUri::try_from(str_uri).unwrap();
+        let uri: FFIUri = str_uri.parse().unwrap();
         assert_eq!(uri, expected_uri);
 
         let string_uri = String::from("mock/a");
-        let uri = FFIUri::try_from(string_uri).unwrap();
+        let uri: FFIUri = string_uri.parse().unwrap();
         assert_eq!(uri, expected_uri);
     }
 

--- a/packages/plugins/fs/tests/it/main.rs
+++ b/packages/plugins/fs/tests/it/main.rs
@@ -1,5 +1,5 @@
 use polywrap_client::client::PolywrapClient;
-use polywrap_core::{client::ClientConfig, uri::Uri};
+use polywrap_core::client::ClientConfig;
 use polywrap_fs_plugin::FileSystemPlugin;
 use polywrap_msgpack_serde::to_vec;
 use polywrap_resolvers::static_resolver::{StaticResolver, StaticResolverLike};
@@ -10,6 +10,8 @@ use serde_bytes::ByteBuf;
 use std::path::Path;
 use std::sync::Arc;
 use std::{env, fs};
+
+const FILE_SYSTEM_PLUGIN_URI: &str = "plugin/file-system";
 
 fn clean_up_temp_files() -> std::io::Result<()> {
     let current_dir = env::current_dir().unwrap();
@@ -37,7 +39,7 @@ fn get_client() -> PolywrapClient {
     let package = Arc::new(plugin_pkg);
 
     let resolver = StaticResolver::from(vec![StaticResolverLike::Package(
-        Uri::try_from("plugin/file-system").unwrap(),
+        FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         package,
     )]);
 
@@ -61,7 +63,7 @@ fn can_read_a_file() {
 
     let expected_contents = fs::read(&sample_file_path).unwrap();
     let result = client.invoke::<ByteBuf>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "readFile",
         Some(
             &to_vec(&ReadFileArgs {
@@ -86,7 +88,7 @@ fn should_fail_reading_a_nonexistent_file() {
     let non_existent_file_path = current_dir.join("nonexistent.txt");
 
     let result = client.invoke::<Vec<u8>>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "readFile",
         Some(
             &to_vec(&ReadFileArgs {
@@ -114,7 +116,7 @@ fn should_read_a_utf8_encoded_file_as_a_string() {
 
     let expected_contents = fs::read_to_string(&sample_file_path).unwrap();
     let result = client.invoke::<String>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "readFileAsString",
         Some(
             &to_vec(&ReadFileArgsAsString {
@@ -164,7 +166,7 @@ fn should_return_whether_a_file_exists_or_not() {
     let sample_file_path = current_dir.join("tests/samples/sample.txt");
 
     let result_file_exists = client.invoke::<bool>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "exists",
         Some(
             &to_vec(&ReadFileArgs {
@@ -184,7 +186,7 @@ fn should_return_whether_a_file_exists_or_not() {
     let nonexistent_file_path = current_dir.join("samples/this-file-should-not-exist.txt");
 
     let result_file_missing = client.invoke::<bool>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "exists",
         Some(
             &to_vec(&ReadFileArgs {
@@ -218,7 +220,7 @@ fn should_write_byte_data_to_a_file() {
 
     let bytes = vec![0, 1, 2, 3];
     let result = client.invoke::<Option<bool>>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "writeFile",
         Some(
             &to_vec(&WriteFileArgs {
@@ -255,7 +257,7 @@ fn should_remove_a_file() {
     fs::write(&temp_file_path, "test file contents").unwrap();
 
     let result = client.invoke::<bool>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "rm",
         Some(
             &to_vec(&RmArgs {
@@ -287,7 +289,7 @@ fn should_remove_a_directory_with_files_recursively() {
     fs::write(&file_in_dir_path, "test file contents").unwrap();
 
     let result = client.invoke::<bool>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "rm",
         Some(
             &to_vec(&RmArgs {
@@ -321,7 +323,7 @@ fn should_create_a_directory() {
     clean_up_temp_files().unwrap();
 
     let result = client.invoke::<bool>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "mkdir",
         Some(
             &to_vec(&MkDirArgs {
@@ -351,7 +353,7 @@ fn should_create_a_directory_recursively() {
     let dir_in_dir_path = temp_dir_path.join("inner");
 
     let result = client.invoke::<bool>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "mkdir",
         Some(
             &to_vec(&MkDirArgs {
@@ -387,7 +389,7 @@ fn should_remove_a_directory() {
     fs::create_dir(&temp_dir_path).unwrap();
 
     let result = client.invoke::<bool>(
-        &Uri::try_from("plugin/file-system").unwrap(),
+        &FILE_SYSTEM_PLUGIN_URI.parse().unwrap(),
         "rmdir",
         Some(
             &to_vec(&RmDirArgs {

--- a/packages/plugins/http/src/parse_response.rs
+++ b/packages/plugins/http/src/parse_response.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::io::Read;
 
 use crate::wrap::types::{Response, ResponseType};
-use polywrap_plugin::{error::PluginError, Map};
+use polywrap_plugin::error::PluginError;
 
 pub fn parse_response(
     response: ureq::Response,

--- a/packages/plugins/http/tests/it/get.rs
+++ b/packages/plugins/http/tests/it/get.rs
@@ -1,4 +1,4 @@
-use polywrap_core::uri::Uri;
+use polywrap_core::{macros::uri, uri::Uri};
 use polywrap_http_plugin::wrap::types::Response;
 use polywrap_msgpack_serde::to_vec;
 use polywrap_plugin::{Map, JSON};
@@ -21,11 +21,14 @@ struct ArgsGet {
 fn simple_get() {
     let response = get_client()
         .invoke::<Response>(
-            &Uri::try_from("plugin/http").unwrap(),
+            &uri!("plugin/http"),
             "get",
-            Some(&to_vec(&ArgsGet {
-                url: "https://jsonplaceholder.typicode.com/todos/1".to_string(),
-            }).unwrap()),
+            Some(
+                &to_vec(&ArgsGet {
+                    url: "https://jsonplaceholder.typicode.com/todos/1".to_string(),
+                })
+                .unwrap(),
+            ),
             None,
             None,
         )
@@ -64,7 +67,7 @@ fn params_get() {
     };
     let response = get_client()
         .invoke::<Response>(
-            &Uri::try_from("plugin/http").unwrap(),
+            &uri!("plugin/http"),
             "get",
             Some(&to_vec(&args).unwrap()),
             None,

--- a/packages/plugins/http/tests/it/main.rs
+++ b/packages/plugins/http/tests/it/main.rs
@@ -1,13 +1,9 @@
-use polywrap_http_plugin::HttpPlugin;
 use polywrap_client::client::PolywrapClient;
-use polywrap_core::{
-    client::ClientConfig,
-    uri::Uri,
-};
+use polywrap_core::{client::ClientConfig, macros::uri, uri::Uri};
+use polywrap_http_plugin::HttpPlugin;
+use polywrap_plugin::package::PluginPackage;
 use polywrap_resolvers::static_resolver::{StaticResolver, StaticResolverLike};
-use polywrap_plugin::{package::PluginPackage};
-use std::{sync::Arc};
-
+use std::sync::Arc;
 
 mod get;
 mod post;
@@ -17,7 +13,7 @@ pub fn get_client() -> PolywrapClient {
     let package = Arc::new(PluginPackage::from(http_plugin));
 
     let resolver = StaticResolver::from(vec![StaticResolverLike::Package(
-        Uri::try_from("plugin/http").unwrap(),
+        uri!("plugin/http"),
         package,
     )]);
 

--- a/packages/plugins/http/tests/it/post.rs
+++ b/packages/plugins/http/tests/it/post.rs
@@ -2,6 +2,7 @@ use polywrap_client::{
     core::uri::Uri,
     plugin::JSON::{from_str, json},
 };
+use polywrap_core::macros::uri;
 use polywrap_http_plugin::wrap::types::{Request, Response};
 use polywrap_msgpack_serde::to_vec;
 use serde::{Deserialize, Serialize};
@@ -27,7 +28,7 @@ fn post_method() {
     });
     let response = get_client()
         .invoke::<Response>(
-            &Uri::try_from("plugin/http").unwrap(),
+            &uri!("plugin/http"),
             "post",
             Some(
                 &to_vec(&ArgsPost {

--- a/packages/resolver-extensions/src/extendable_uri_resolver.rs
+++ b/packages/resolver-extensions/src/extendable_uri_resolver.rs
@@ -2,6 +2,7 @@ use core::fmt;
 use polywrap_core::{
     error::Error,
     invoker::Invoker,
+    macros::uri,
     resolution::{
         uri_resolution_context::{UriPackageOrWrapper, UriResolutionContext},
         uri_resolver::UriResolver,
@@ -34,8 +35,8 @@ impl UriResolverAggregatorBase for ExtendableUriResolver {
         invoker: &dyn Invoker,
         resolution_context: Arc<Mutex<UriResolutionContext>>,
     ) -> Result<Vec<Arc<dyn UriResolver>>, Error> {
-        let implementations = invoker
-            .get_implementations(&Uri::try_from("wrap://ens/uri-resolver.core.polywrap.eth")?)?;
+        let implementations =
+            invoker.get_implementations(&uri!("wrap://ens/uri-resolver.core.polywrap.eth"))?;
 
         let resolvers = implementations
             .into_iter()

--- a/packages/resolver-extensions/src/uri_resolver_wrapper.rs
+++ b/packages/resolver-extensions/src/uri_resolver_wrapper.rs
@@ -120,7 +120,7 @@ impl UriResolver for UriResolverWrapper {
         );
 
         let uri = if let Some(resolved_uri) = result.uri {
-            Uri::try_from(resolved_uri)?
+            resolved_uri.parse()?
         } else {
             uri.clone()
         };


### PR DESCRIPTION
Using `"test/path".parse()` instead of `Uri::try_from("test/path")`
`.parse()` comes from the core trait `FromStr`