### PR TITLE
chore(native): move uri from string to global function

### DIFF
--- a/packages/native/src/builder.rs
+++ b/packages/native/src/builder.rs
@@ -106,18 +106,16 @@ impl FFIBuilderConfig {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::collections::HashMap;
 
-    use polywrap_client::{
-        core::{macros::uri, uri::Uri},
-    };
+    use polywrap_client::core::{macros::uri, uri::Uri};
     use polywrap_msgpack_serde::to_vec;
     use polywrap_tests_utils::mocks::{
         get_different_mock_package, get_different_mock_wrapper, get_mock_package, get_mock_wrapper,
     };
     use serde::Serialize;
 
-    use crate::{package::FFIWrapPackage, uri::FFIUri, wrapper::FFIWrapper};
+    use crate::{package::FFIWrapPackage, uri::{ffi_uri_from_string}, wrapper::FFIWrapper};
 
     use super::FFIBuilderConfig;
 
@@ -134,7 +132,7 @@ mod test {
     #[test]
     fn adds_and_removes_env() {
         let builder = FFIBuilderConfig::new();
-        let uri = Arc::new(FFIUri::from_string("wrap://ens/some.eth"));
+        let uri = ffi_uri_from_string("wrap://ens/some.eth").unwrap();
         let env = to_vec(&Args {
             foo: "bar".to_string(),
         })
@@ -164,10 +162,10 @@ mod test {
     fn adds_and_removes_package() {
         let builder = FFIBuilderConfig::new();
         let mock_package: Box<dyn FFIWrapPackage> = Box::new(get_mock_package());
-        let uri_mock_package = Arc::new(FFIUri::from_string("package/a"));
+        let uri_mock_package = ffi_uri_from_string("package/a").unwrap();
         let different_mock_package: Box<dyn FFIWrapPackage> =
             Box::new(get_different_mock_package());
-        let uri_different_mock_package = Arc::new(FFIUri::from_string("package/b"));
+        let uri_different_mock_package = ffi_uri_from_string("package/b").unwrap();
 
         builder.add_package(uri_mock_package.clone(), mock_package);
         builder.add_package(uri_different_mock_package, different_mock_package);
@@ -201,12 +199,12 @@ mod test {
     fn adds_and_removes_wrapper() {
         let builder = FFIBuilderConfig::new();
         let mock_package: Box<dyn FFIWrapper> = Box::new(get_mock_wrapper());
-        let uri_mock_wrapper = Arc::new(FFIUri::from_string("wrap/a"));
+        let uri_mock_wrapper = ffi_uri_from_string("wrap/a");
         let different_mock_wrapper: Box<dyn FFIWrapper> = Box::new(get_different_mock_wrapper());
-        let uri_different_mock_wrapper = Arc::new(FFIUri::from_string("wrap/b"));
+        let uri_different_mock_wrapper = ffi_uri_from_string("wrap/b");
 
-        builder.add_wrapper(uri_mock_wrapper.clone(), mock_package);
-        builder.add_wrapper(uri_different_mock_wrapper, different_mock_wrapper);
+        builder.add_wrapper(uri_mock_wrapper.clone().unwrap(), mock_package);
+        builder.add_wrapper(uri_different_mock_wrapper.unwrap(), different_mock_wrapper);
         assert_eq!(
             builder
                 .inner_builder
@@ -219,7 +217,7 @@ mod test {
             2
         );
 
-        builder.remove_wrapper(uri_mock_wrapper);
+        builder.remove_wrapper(uri_mock_wrapper.unwrap());
         assert_eq!(
             builder
                 .inner_builder
@@ -237,12 +235,12 @@ mod test {
     fn adds_and_removes_redirects() {
         let builder = FFIBuilderConfig::new();
         builder.add_redirect(
-            Arc::new(FFIUri::from_string("wrap/a")),
-            Arc::new(FFIUri::from_string("wrap/b")),
+            ffi_uri_from_string("wrap/a").unwrap(),
+            ffi_uri_from_string("wrap/b").unwrap(),
         );
         builder.add_redirect(
-            Arc::new(FFIUri::from_string("wrap/c")),
-            Arc::new(FFIUri::from_string("wrap/d")),
+            ffi_uri_from_string("wrap/c").unwrap(),
+            ffi_uri_from_string("wrap/d").unwrap(),
         );
 
         let redirects = builder
@@ -264,9 +262,9 @@ mod test {
     #[test]
     fn adds_and_removes_interface_implementation() {
         let builder = FFIBuilderConfig::new();
-        let interface_uri = Arc::new(FFIUri::from_string("wrap://ens/interface.eth"));
-        let implementation_a_uri = Arc::new(FFIUri::from_string("wrap://ens/implementation-a.eth"));
-        let implementation_b_uri = Arc::new(FFIUri::from_string("wrap://ens/implementation-b.eth"));
+        let interface_uri = ffi_uri_from_string("wrap://ens/interface.eth").unwrap();
+        let implementation_a_uri = ffi_uri_from_string("wrap://ens/implementation-a.eth").unwrap();
+        let implementation_b_uri = ffi_uri_from_string("wrap://ens/implementation-b.eth").unwrap();
 
         builder.add_interface_implementation(interface_uri.clone(), implementation_a_uri);
         builder.add_interface_implementation(interface_uri.clone(), implementation_b_uri.clone());

--- a/packages/native/src/client.rs
+++ b/packages/native/src/client.rs
@@ -175,7 +175,7 @@ mod test {
     use serde::Serialize;
 
     use crate::uri::ffi_uri_from_string;
-    use crate::{client::FFIClient, invoker::FFIInvoker, uri::FFIUri, wrapper::FFIWrapper};
+    use crate::{client::FFIClient, invoker::FFIInvoker, wrapper::FFIWrapper};
 
     #[test]
     fn ffi_invoke_raw() {

--- a/packages/native/src/invoker.rs
+++ b/packages/native/src/invoker.rs
@@ -60,17 +60,17 @@ impl FFIInvoker {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, sync::Arc};
+    use std::collections::HashMap;
 
     use polywrap_tests_utils::mocks::get_mock_invoker;
 
-    use crate::{invoker::FFIInvoker, uri::FFIUri};
+    use crate::{invoker::FFIInvoker, uri::ffi_uri_from_string};
 
     #[test]
     fn test_ffi_invoker() {
         let ffi_invoker = FFIInvoker(get_mock_invoker());
 
-        let uri = Arc::new(FFIUri::from_string("mock/a"));
+        let uri = ffi_uri_from_string("mock/a").unwrap();
         let response = ffi_invoker.invoke_raw(uri, "foo".to_string(), None, None, None);
         assert_eq!(response.unwrap(), vec![3]);
     }
@@ -79,7 +79,7 @@ mod test {
     fn test_ffi_get_implementations() {
         let ffi_invoker = FFIInvoker(get_mock_invoker());
 
-        let uri = Arc::new(FFIUri::from_string("mock/a"));
+        let uri = ffi_uri_from_string("mock/a").unwrap();
         let response = ffi_invoker.get_implementations(uri.clone());
         assert_eq!(response.unwrap(), vec![uri]);
     }
@@ -93,7 +93,7 @@ mod test {
             response.unwrap(),
             HashMap::from([(
                 ("mock/a".to_string()),
-                vec![Arc::new(FFIUri::from_string("mock/b"))]
+                vec![ffi_uri_from_string("mock/b").unwrap()]
             )])
         );
     }
@@ -101,8 +101,8 @@ mod test {
     #[test]
     fn test_get_env_by_uri() {
         let ffi_invoker = FFIInvoker(get_mock_invoker());
-        let ffi_uri = FFIUri::from_string("mock/a");
-        let response = ffi_invoker.get_env_by_uri(Arc::new(ffi_uri));
+        let ffi_uri = ffi_uri_from_string("mock/a");
+        let response = ffi_invoker.get_env_by_uri(ffi_uri.unwrap());
         assert_eq!(response.unwrap(), [0, 4]);
     }
 }

--- a/packages/native/src/polywrap_native.udl
+++ b/packages/native/src/polywrap_native.udl
@@ -21,7 +21,9 @@ interface FFIError {
 interface FFIUri {
   constructor([ByRef] string authority, [ByRef] string path, [ByRef] string uri);
 
-  string to_string_uri();
+  string authority();
+  string path();
+  string to_string();
 };
 
 interface FFIInvoker {

--- a/packages/native/src/polywrap_native.udl
+++ b/packages/native/src/polywrap_native.udl
@@ -21,9 +21,6 @@ interface FFIError {
 interface FFIUri {
   constructor([ByRef] string authority, [ByRef] string path, [ByRef] string uri);
 
-  [Name=from_string]
-  constructor([ByRef] string uri);
-
   string to_string_uri();
 };
 
@@ -154,4 +151,7 @@ interface FFIBuilderConfig {
   FFIClient build();
 };
 
-namespace polywrap_native { };
+namespace polywrap_native {
+  [Throws=FFIError]
+  FFIUri ffi_uri_from_string([ByRef] string uri);
+};

--- a/packages/native/src/resolvers/_static.rs
+++ b/packages/native/src/resolvers/_static.rs
@@ -74,7 +74,7 @@ mod test {
             resolution_context::FFIUriResolutionContext,
             uri_package_or_wrapper::{FFIUriPackageOrWrapper, FFIUriPackageOrWrapperKind},
         },
-        uri::{FFIUri, ffi_uri_from_string},
+        uri::ffi_uri_from_string,
     };
 
     use super::FFIStaticUriResolver;

--- a/packages/native/src/resolvers/_static.rs
+++ b/packages/native/src/resolvers/_static.rs
@@ -74,13 +74,13 @@ mod test {
             resolution_context::FFIUriResolutionContext,
             uri_package_or_wrapper::{FFIUriPackageOrWrapper, FFIUriPackageOrWrapperKind},
         },
-        uri::FFIUri,
+        uri::{FFIUri, ffi_uri_from_string},
     };
 
     use super::FFIStaticUriResolver;
 
     #[test]
-    fn ff_static_resolver_returns_error_with_bad_uri() {
+    fn ffi_static_resolver_returns_error_with_bad_uri() {
         let mock_uri_package_or_wrapper = get_mock_uri_package_or_wrapper();
 
         let ffi_uri_package_or_wrapper: Box<dyn FFIUriPackageOrWrapper> =
@@ -98,9 +98,9 @@ mod test {
     }
 
     #[test]
-    fn ff_try_resolver_uri() {
+    fn ffi_try_resolver_uri() {
         let mock_uri_package_or_wrapper = get_mock_uri_package_or_wrapper();
-        let ffi_uri = Arc::new(FFIUri::from_string("wrap/mock"));
+        let ffi_uri = ffi_uri_from_string("wrap/mock").unwrap();
 
         let ffi_uri_package_or_wrapper: Box<dyn FFIUriPackageOrWrapper> =
             Box::new(mock_uri_package_or_wrapper);

--- a/packages/native/src/uri.rs
+++ b/packages/native/src/uri.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
-use polywrap_client::core::uri::Uri;
+use polywrap_client::core::uri::{ParseError, Uri};
 
 use crate::error::FFIError;
 
@@ -8,7 +8,7 @@ use crate::error::FFIError;
 pub struct FFIUri(pub Uri);
 
 pub fn ffi_uri_from_string(uri: &str) -> Result<Arc<FFIUri>, FFIError> {
-    let uri = Uri::try_from(uri);
+    let uri: Result<Uri, ParseError> = uri.parse();
     uri.map_err(|e| FFIError::UriParseError { err: e.to_string() })
         .map(|v| Arc::new(FFIUri(v)))
 }

--- a/packages/native/src/uri.rs
+++ b/packages/native/src/uri.rs
@@ -24,7 +24,15 @@ impl FFIUri {
         }
     }
 
-    pub fn to_string_uri(&self) -> String {
+    pub fn authority(&self) -> String {
+        self.0.authority().to_string()
+    }
+
+    pub fn path(&self) -> String {
+        self.0.path().to_string()
+    }
+
+    pub fn to_string(&self) -> String {
         self.0.to_string()
     }
 }
@@ -138,5 +146,14 @@ mod test {
         let ffi_uri = ffi_uri_from_string("wrap://mock/a");
         let expected_uri = uri!("mock/a");
         assert_eq!(ffi_uri.unwrap().0, expected_uri);
+    }
+
+    #[test]
+    pub fn getters() {
+        let ffi_uri = ffi_uri_from_string("mock/a").unwrap();
+
+        assert_eq!(ffi_uri.authority(), "mock");
+        assert_eq!(ffi_uri.path(), "a");
+        assert_eq!(ffi_uri.to_string(), "wrap://mock/a");
     }
 }


### PR DESCRIPTION
this pr aims to remove the `unwrap` in the `from_string` method of `FFIUri`; being able to handle the error across the boundary (in swift in my case). I tried to first make it a static function inside of `FFIUri` but uniffi just doesn't accept it and I also couldn't keep it as a constructor while also returning a `Result` type; hence, that's why its now a global function