### PR TITLE
chore(native): expose add interface implementations in builder

### DIFF
--- a/packages/core/src/resolution/helpers.rs
+++ b/packages/core/src/resolution/helpers.rs
@@ -88,18 +88,6 @@ pub fn get_implementations(
     }
 
     Ok(implementation_uris)
-    // for interface in interfaces.keys() {
-
-    //     let mut fully_resolved_uri = implementation.clone();
-    //     if let Some(l) = loader {
-    //         let redirect_uri = l.try_resolve_uri(
-    //             &implementation.clone(),
-    //             resolution_context
-    //         ).await;
-    //     };
-
-    //     if implementation_uris.contains(x)
-    // }
 }
 
 pub fn get_env_from_resolution_path(

--- a/packages/native/src/builder.rs
+++ b/packages/native/src/builder.rs
@@ -39,9 +39,9 @@ impl FFIBuilderConfig {
     pub fn add_interface_implementations(
         &self,
         interface_uri: Arc<FFIUri>,
-        implementations_uri: Vec<Arc<FFIUri>>,
+        implementation_uris: Vec<Arc<FFIUri>>,
     ) {
-        let implementations = implementations_uri
+        let implementations = implementation_uris
             .clone()
             .iter()
             .map(|i| i.0.clone())

--- a/packages/native/src/polywrap_native.udl
+++ b/packages/native/src/polywrap_native.udl
@@ -141,6 +141,7 @@ interface FFIBuilderConfig {
   constructor();
   void add_env(FFIUri uri, sequence<u8> env);
   void remove_env(FFIUri uri);
+  void add_interface_implementations(FFIUri interface_uri, sequence<FFIUri> implementation_uri);
   void add_interface_implementation(FFIUri interface_uri, FFIUri implementation_uri);
   void remove_interface_implementation(FFIUri interface_uri, FFIUri implementation_uri);
   void add_wrapper(FFIUri uri, FFIWrapper wrapper);

--- a/packages/native/src/polywrap_native.udl
+++ b/packages/native/src/polywrap_native.udl
@@ -141,7 +141,7 @@ interface FFIBuilderConfig {
   constructor();
   void add_env(FFIUri uri, sequence<u8> env);
   void remove_env(FFIUri uri);
-  void add_interface_implementations(FFIUri interface_uri, sequence<FFIUri> implementation_uri);
+  void add_interface_implementations(FFIUri interface_uri, sequence<FFIUri> implementation_uris);
   void add_interface_implementation(FFIUri interface_uri, FFIUri implementation_uri);
   void remove_interface_implementation(FFIUri interface_uri, FFIUri implementation_uri);
   void add_wrapper(FFIUri uri, FFIWrapper wrapper);


### PR DESCRIPTION
this aims to expose the add interface implementations method in the ffi builder