### PR TITLE
Fix: reverted FFI Uri method name to to_string_uri

### DIFF
--- a/packages/native/src/polywrap_native.udl
+++ b/packages/native/src/polywrap_native.udl
@@ -23,7 +23,7 @@ interface FFIUri {
 
   string authority();
   string path();
-  string to_string();
+  string to_string_uri();
 };
 
 interface FFIInvoker {

--- a/packages/native/src/uri.rs
+++ b/packages/native/src/uri.rs
@@ -32,7 +32,7 @@ impl FFIUri {
         self.0.path().to_string()
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn to_string_uri(&self) -> String {
         self.0.to_string()
     }
 }
@@ -45,7 +45,7 @@ impl PartialEq for FFIUri {
 
 impl From<FFIUri> for String {
     fn from(uri: FFIUri) -> Self {
-        uri.to_string()
+        uri.to_string_uri()
     }
 }
 


### PR DESCRIPTION
A recent PR https://github.com/polywrap/rust-client/pull/156 changed the method name on FFI Uri from `to_string_uri` to `to_string`. The name `to_string` produces invalid bindings for Kotlin. This PR reverts the change.