### PR TITLE
Remove use of 64 bit numbers in Ethers Wallet plugin

### DIFF
--- a/packages/plugins/ethereum-wallet/src/connection.rs
+++ b/packages/plugins/ethereum-wallet/src/connection.rs
@@ -53,10 +53,10 @@ impl Connection {
     }
 
     pub fn from_network(network: KnownNetwork, signer: Option<String>) -> Result<Self, String> {
-        let name = get_name(network);
+        let name = get_name(&network);
 
         if name.is_none() {
-            return Err(format!("Given network: {:#?} is not supported", network));
+            return Err(format!("Given network: {:#?} is not supported", &network));
         };
 
         let name = name.unwrap();

--- a/packages/plugins/ethereum-wallet/src/networks.rs
+++ b/packages/plugins/ethereum-wallet/src/networks.rs
@@ -3,50 +3,102 @@ use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum KnownNetwork {
-    Mainnet = 1,
-    Goerli = 5,
-    BinanceSmartChain = 56,
-    Sepolia = 11155111,
-    CeloMainnet = 42220,
-    CeloAlfajores = 44787,
-    AvalancheMainnet = 43114,
-    AvalancheFuji = 43113,
-    PalmMainnet = 11297108109,
-    PalmTestnet = 11297108099,
-    AuroraMainnet = 1313161554,
-    AuroraTestnet = 1313161555,
+    Mainnet,
+    Goerli,
+    BinanceSmartChain,
+    Sepolia,
+    CeloMainnet,
+    CeloAlfajores,
+    AvalancheMainnet,
+    AvalancheFuji,
+    PalmMainnet,
+    PalmTestnet,
+    AuroraMainnet,
+    AuroraTestnet,
+}
+
+impl KnownNetwork {
+    fn chain_id(&self) -> &'static str {
+        match self {
+            Self::Mainnet => "1",
+            Self::Goerli => "5",
+            Self::BinanceSmartChain => "56",
+            Self::Sepolia => "11155111",
+            Self::CeloMainnet => "42220",
+            Self::CeloAlfajores => "44787",
+            Self::AvalancheMainnet => "43114",
+            Self::AvalancheFuji => "43113",
+            Self::PalmMainnet => "11297108109",
+            Self::PalmTestnet => "11297108099",
+            Self::AuroraMainnet => "1313161554",
+            Self::AuroraTestnet => "1313161555",
+        }
+    }
 }
 
 lazy_static! {
     static ref ALIASES: HashMap<String, KnownNetwork> = {
         let mut m = HashMap::new();
-        m.insert("1".to_string(), KnownNetwork::Mainnet);
         m.insert("mainnet".to_string(), KnownNetwork::Mainnet);
-        m.insert("5".to_string(), KnownNetwork::Goerli);
-        m.insert("goerli".to_string(), KnownNetwork::Goerli);
-        m.insert("11155111".to_string(), KnownNetwork::Sepolia);
-        m.insert("sepolia".to_string(), KnownNetwork::Sepolia);
-        m.insert("56".to_string(), KnownNetwork::BinanceSmartChain);
-        m.insert("binance".to_string(), KnownNetwork::BinanceSmartChain);
-        m.insert("42220".to_string(), KnownNetwork::CeloMainnet);
-        m.insert("celo_mainnet".to_string(), KnownNetwork::CeloMainnet);
-        m.insert("44787".to_string(), KnownNetwork::CeloAlfajores);
-        m.insert("celo_alfajores".to_string(), KnownNetwork::CeloAlfajores);
-        m.insert("43114".to_string(), KnownNetwork::AvalancheMainnet);
         m.insert(
-            "avalanche_mainnet".to_string(),
+            KnownNetwork::Mainnet.chain_id().to_string(),
+            KnownNetwork::Mainnet
+        );
+        m.insert("goerli".to_string(), KnownNetwork::Goerli);
+        m.insert(
+            KnownNetwork::Goerli.chain_id().to_string(),
+            KnownNetwork::Goerli
+        );
+        m.insert("sepolia".to_string(), KnownNetwork::Sepolia);
+        m.insert(
+            KnownNetwork::Sepolia.chain_id().to_string(),
+            KnownNetwork::Sepolia
+        );
+        m.insert("binance".to_string(), KnownNetwork::BinanceSmartChain);
+        m.insert(
+            KnownNetwork::BinanceSmartChain.chain_id().to_string(),
+            KnownNetwork::BinanceSmartChain,
+        );
+        m.insert("celo-mainnet".to_string(), KnownNetwork::CeloMainnet);
+        m.insert(
+            KnownNetwork::CeloMainnet.chain_id().to_string(),
+            KnownNetwork::CeloMainnet,
+        );
+        m.insert("celo-alfajores".to_string(), KnownNetwork::CeloAlfajores);
+        m.insert(
+            KnownNetwork::CeloAlfajores.chain_id().to_string(),
+            KnownNetwork::CeloAlfajores,
+        );
+        m.insert("avalanche-mainnet".to_string(), KnownNetwork::AvalancheMainnet);
+        m.insert(
+            KnownNetwork::AvalancheMainnet.chain_id().to_string(),
             KnownNetwork::AvalancheMainnet,
         );
-        m.insert("43113".to_string(), KnownNetwork::AvalancheFuji);
-        m.insert("avalanche_fuji".to_string(), KnownNetwork::AvalancheFuji);
-        m.insert("11297108109".to_string(), KnownNetwork::PalmMainnet);
-        m.insert("palm_mainnet".to_string(), KnownNetwork::PalmMainnet);
-        m.insert("11297108099".to_string(), KnownNetwork::PalmTestnet);
-        m.insert("palm_testnet".to_string(), KnownNetwork::PalmTestnet);
-        m.insert("1313161554".to_string(), KnownNetwork::AuroraMainnet);
-        m.insert("aurora_mainnet".to_string(), KnownNetwork::AuroraMainnet);
-        m.insert("1313161555".to_string(), KnownNetwork::AuroraTestnet);
-        m.insert("aurora_testnet".to_string(), KnownNetwork::AuroraTestnet);
+        m.insert("avalanche-fuji".to_string(), KnownNetwork::AvalancheFuji);
+        m.insert(
+            KnownNetwork::AvalancheFuji.chain_id().to_string(),
+            KnownNetwork::AvalancheFuji,
+        );
+        m.insert("palm-mainnet".to_string(), KnownNetwork::PalmMainnet);
+        m.insert(
+            KnownNetwork::PalmMainnet.chain_id().to_string(),
+            KnownNetwork::PalmMainnet,
+        );
+        m.insert("palm-testnet".to_string(), KnownNetwork::PalmTestnet);
+        m.insert(
+            KnownNetwork::PalmTestnet.chain_id().to_string(),
+            KnownNetwork::PalmTestnet,
+        );
+        m.insert("aurora-mainnet".to_string(), KnownNetwork::AuroraMainnet);
+        m.insert(
+            KnownNetwork::AuroraMainnet.chain_id().to_string(),
+            KnownNetwork::AuroraMainnet,
+        );
+        m.insert("aurora-testnet".to_string(), KnownNetwork::AuroraTestnet);
+        m.insert(
+            KnownNetwork::AuroraTestnet.chain_id().to_string(),
+            KnownNetwork::AuroraTestnet,
+        );
         m
     };
     static ref NETWORK_NAMES: HashMap<KnownNetwork, &'static str> = {
@@ -71,6 +123,6 @@ pub fn from_alias(alias: &str) -> Option<KnownNetwork> {
     ALIASES.get(&alias.to_lowercase()).cloned()
 }
 
-pub fn get_name(network: KnownNetwork) -> Option<&'static str> {
-    NETWORK_NAMES.get(&network).cloned()
+pub fn get_name(network: &KnownNetwork) -> Option<&'static str> {
+    NETWORK_NAMES.get(network).cloned()
 }


### PR DESCRIPTION
This is necessary for 32 bit architecture support