### PR TITLE
scripts(release): add ethereum wallet plugin

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -16,6 +16,7 @@ packages=(
   "client"
   "plugins/http"
   "plugins/fs"
+  "plugins/ethereum-wallet"
   "default-config"
 )
 


### PR DESCRIPTION
when doing the release i noticed that we missed this. I went ahead and deployed those manually so we're ready for next release