### PR TITLE
Update Wasmer, Uniffi, polywrap_msgpack_serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ polywrap_fs_plugin = { version = "0.1.6-beta.13", path = "packages/plugins/fs" }
 polywrap_http_plugin = { version = "0.1.6-beta.13", path = "packages/plugins/http"  }
 polywrap_ethereum_wallet_plugin = { version = "0.1.6-beta.13", path = "packages/plugins/ethereum-wallet" }
 
-polywrap_msgpack_serde = "0.0.2-beta.4"
+polywrap_msgpack_serde = "0.0.2-beta.5"
 tokio = { version = "1.28", features = ["full"] }
 
 serde = { version = "1.0.145", features = ["derive"] }

--- a/packages/native/Cargo.toml
+++ b/packages/native/Cargo.toml
@@ -20,10 +20,10 @@ thiserror.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 
-uniffi = { version = "0.23.0", features = [ "cli" ] }
+uniffi = { version = "0.24.2", features = [ "cli" ] }
 
 [build-dependencies]
-uniffi = { version = "0.23.0", features = [ "build" ] }
+uniffi = { version = "0.24.2", features = [ "build" ] }
 
 [dev-dependencies]
 polywrap_tests_utils.workspace = true

--- a/packages/wasm/Cargo.toml
+++ b/packages/wasm/Cargo.toml
@@ -17,7 +17,7 @@ thiserror.workspace = true
 serde_json.workspace = true
 base64.workspace = true
 
-wasmer = "3.1.1"
+wasmer = "4.1.0"
 bytes = "1.4.0"
 
 [dev-dependencies]

--- a/packages/wasm/src/wasm_module.rs
+++ b/packages/wasm/src/wasm_module.rs
@@ -35,7 +35,7 @@ impl SerializedWasmModule {
     // Deserialize the module back into a CompiledWasmModule.
     pub fn deserialize(self) -> Result<CompiledWasmModule, WrapperError> {
         let store = Store::default();
-        let wasmer_module = Module::deserialize_checked(&store, &*self.compiled_bytes)?;
+        let wasmer_module = unsafe { Module::deserialize(&store, &*self.compiled_bytes)? };
 
         Ok(CompiledWasmModule {
             module: wasmer_module,


### PR DESCRIPTION
All are bumped to latest versions. The tests failing in this PR are the same tests that are failing in `main`.