### PR TITLE
chore(native): get interfaces use string as string

### DIFF
--- a/packages/native/src/client.rs
+++ b/packages/native/src/client.rs
@@ -59,13 +59,13 @@ impl FFIClient {
             .collect())
     }
 
-    pub fn get_interfaces(&self) -> Option<HashMap<Arc<FFIUri>, Vec<Arc<FFIUri>>>> {
+    pub fn get_interfaces(&self) -> Option<HashMap<String, Vec<Arc<FFIUri>>>> {
         if let Some(interfaces) = self.inner_client.get_interfaces() {
             let interfaces = interfaces
                 .into_iter()
                 .map(|(key, uris)| {
                     let uris = uris.into_iter().map(|uri| Arc::new(uri.into())).collect();
-                    (Arc::new(key.into()), uris)
+                    (key.to_string(), uris)
                 })
                 .collect();
 
@@ -221,7 +221,7 @@ mod test {
         assert_eq!(
             response.unwrap(),
             HashMap::from([(
-                ffi_uri_from_string("mock/c").unwrap(),
+                "mock/c".to_string(),
                 vec![ffi_uri_from_string("mock/d").unwrap()]
             )])
         );

--- a/packages/native/src/client.rs
+++ b/packages/native/src/client.rs
@@ -221,7 +221,7 @@ mod test {
         assert_eq!(
             response.unwrap(),
             HashMap::from([(
-                "mock/c".to_string(),
+                "wrap://mock/c".to_string(),
                 vec![ffi_uri_from_string("mock/d").unwrap()]
             )])
         );

--- a/packages/native/src/invoker.rs
+++ b/packages/native/src/invoker.rs
@@ -93,7 +93,7 @@ mod test {
         assert_eq!(
             response.unwrap(),
             HashMap::from([(
-                "mock/a".to_string(),
+                "wrap://mock/a".to_string(),
                 vec![ffi_uri_from_string("mock/b").unwrap()]
             )])
         );

--- a/packages/native/src/invoker.rs
+++ b/packages/native/src/invoker.rs
@@ -33,14 +33,14 @@ impl FFIInvoker {
         Ok(uris)
     }
 
-    pub fn get_interfaces(&self) -> Option<HashMap<Arc<FFIUri>, Vec<Arc<FFIUri>>>> {
+    pub fn get_interfaces(&self) -> Option<HashMap<String, Vec<Arc<FFIUri>>>> {
         let interfaces = self.0.get_interfaces();
         let interfaces = interfaces.map(|interfaces| {
             interfaces
                 .into_iter()
                 .map(|(key, value)| {
                     (
-                        Arc::new(FFIUri(key.clone())),
+                        key.to_string(),
                         value
                             .into_iter()
                             .map(|uri| Arc::new(FFIUri(uri.clone())))
@@ -93,7 +93,7 @@ mod test {
         assert_eq!(
             response.unwrap(),
             HashMap::from([(
-                ffi_uri_from_string("mock/a").unwrap(),
+                "mock/a".to_string(),
                 vec![ffi_uri_from_string("mock/b").unwrap()]
             )])
         );

--- a/packages/native/src/polywrap_native.udl
+++ b/packages/native/src/polywrap_native.udl
@@ -33,7 +33,7 @@ interface FFIInvoker {
   [Throws=FFIError]
   sequence<FFIUri> get_implementations(FFIUri uri);
 
-  record<FFIUri, sequence<FFIUri>>? get_interfaces();
+  record<DOMString, sequence<FFIUri>>? get_interfaces();
 
   sequence<u8>? get_env_by_uri(FFIUri uri);
 };
@@ -139,7 +139,7 @@ interface FFIClient {
   [Throws=FFIError]
   sequence<FFIUri> get_implementations(FFIUri uri);
 
-  record<FFIUri, sequence<FFIUri>>? get_interfaces();
+  record<DOMString, sequence<FFIUri>>? get_interfaces();
 
   sequence<u8>? get_env_by_uri(FFIUri uri);
 


### PR DESCRIPTION
after trying to update swift client with latest changes; i noticed that we're not able to use `FFIUri` as key of a hashmap (this is told in uniffi doc https://mozilla.github.io/uniffi-rs/udl/builtin_types.html)

that's why i thought something was wrong with this change https://github.com/polywrap/rust-client/pull/190/files#r1276613583 l0l