### PR TITLE
chore: use wasmer LLVM compiler

### DIFF
--- a/packages/wasm/Cargo.toml
+++ b/packages/wasm/Cargo.toml
@@ -19,6 +19,7 @@ base64.workspace = true
 serde_bytes.workspace = true
 
 wasmer = "4.1.0"
+wasmer-compiler-llvm = "4.1.0"
 bytes = "1.4.0"
 
 [dev-dependencies]

--- a/packages/wasm/src/runtime/instance.rs
+++ b/packages/wasm/src/runtime/instance.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use polywrap_core::invoker::Invoker;
 use wasmer::{Instance, Memory, MemoryType, Module, Store, Value};
+use wasmer_compiler_llvm::LLVM;
 
 use crate::error::WrapperError;
 
@@ -63,7 +64,8 @@ impl WasmInstance {
         memory_initial_limits: u8,
         state: Arc<Mutex<State>>,
     ) -> Result<Self, WrapperError> {
-        let mut store = Store::default();
+        let compiler = LLVM::new();
+        let mut store = Store::new(compiler);
         let memory = WasmInstance::create_memory(&mut store, memory_initial_limits)?;
 
         state.lock().unwrap().memory = Some(memory.clone());


### PR DESCRIPTION
based on wasmer documentation, this is the compiler we want to use in any production environment (https://github.com/wasmerio/wasmer/tree/master/lib/compiler-llvm); this will probably improve the UX when doing invocations